### PR TITLE
refactor: update layouts

### DIFF
--- a/app/author/layout.tsx
+++ b/app/author/layout.tsx
@@ -1,0 +1,21 @@
+import Header from '@/shared-components/header'
+import NewsletterSubscription from '@/shared-components/newsletter-subscription'
+import Footer from '@/shared-components/footer'
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <>
+      <Header />
+      {/* main content */}
+      <div className="flex w-full max-w-screen-lg shrink-0 grow flex-col">
+        {children}
+      </div>
+      <NewsletterSubscription />
+      <Footer />
+    </>
+  )
+}

--- a/app/category/layout.tsx
+++ b/app/category/layout.tsx
@@ -1,0 +1,21 @@
+import Header from '@/shared-components/header'
+import NewsletterSubscription from '@/shared-components/newsletter-subscription'
+import Footer from '@/shared-components/footer'
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <>
+      <Header />
+      {/* main content */}
+      <div className="flex w-full max-w-screen-lg shrink-0 grow flex-col">
+        {children}
+      </div>
+      <NewsletterSubscription />
+      <Footer />
+    </>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,6 @@
 import '@/shared-styles/global.css'
 import type { Metadata } from 'next'
 import { Noto_Sans_TC } from 'next/font/google'
-import Header from '@/shared-components/header'
-import NewsletterSubscription from '@/shared-components/newsletter-subscription'
-import Footer from '@/shared-components/footer'
 
 const notoSans = Noto_Sans_TC({
   preload: true,
@@ -24,13 +21,7 @@ export default function RootLayout({
   return (
     <html lang="zh-Hant" className={notoSans.className}>
       <body className="flex min-h-screen w-screen flex-col items-center overflow-x-hidden bg-white has-[#mobile-menu-toggle:checked]:h-screen has-[#mobile-menu-toggle:checked]:overflow-hidden has-[#mobile-menu-toggle:checked]:lg:h-auto has-[#mobile-menu-toggle:checked]:lg:overflow-auto">
-        <Header />
-        {/* main content */}
-        <div className="flex w-full max-w-screen-lg shrink-0 grow flex-col">
-          {children}
-        </div>
-        <NewsletterSubscription />
-        <Footer />
+        {children}
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,9 @@ import { fetchLatestPost, fetchLiveEvent } from '@/app/actions'
 import { fetchPopularPost } from './actions-general'
 import type { ParameterOfComponent } from '@/types/common'
 
+import Header from '@/shared-components/header'
+import NewsletterSubscription from '@/shared-components/newsletter-subscription'
+import Footer from '@/shared-components/footer'
 import SectionDivider from './_components/divider'
 import EditorChoiceSection from './_components/editor-choice/section'
 import TopNewsSection from './_components/top-news/section'
@@ -69,27 +72,34 @@ export default async function Home() {
     }
 
   return (
-    <main className="flex w-full grow flex-col items-center justify-center">
-      <SectionDivider customClasses="hidden md:block" />
-      {/* 編輯精選 */}
-      <EditorChoiceSection />
-      <SectionDivider />
-      {/* 即時新聞/熱門新聞（10則） */}
-      <TopNewsSection postsOfTab={postsOfTab} />
-      <SectionDivider />
-      {/* 短影音新聞 */}
-      <ShortsNewsSection />
-      <SectionDivider />
-      {/* Topic（4則）＋遊戲區 */}
-      <TopicAndGameSection />
-      <SectionDivider />
-      {/* 短影音．二創 */}
-      <ShortsDerivativeSection />
-      <SectionDivider />
-      {/* 最新新聞 */}
-      <LatestNewsSection
-        initialList={latestPosts.slice(startIndexOfLatestNewsSection)}
-      />
-    </main>
+    <>
+      <Header />
+      <div className="flex w-full max-w-screen-lg shrink-0 grow flex-col">
+        <main className="flex w-full grow flex-col items-center justify-center">
+          <SectionDivider customClasses="hidden md:block" />
+          {/* 編輯精選 */}
+          <EditorChoiceSection />
+          <SectionDivider />
+          {/* 即時新聞/熱門新聞（10則） */}
+          <TopNewsSection postsOfTab={postsOfTab} />
+          <SectionDivider />
+          {/* 短影音新聞 */}
+          <ShortsNewsSection />
+          <SectionDivider />
+          {/* Topic（4則）＋遊戲區 */}
+          <TopicAndGameSection />
+          <SectionDivider />
+          {/* 短影音．二創 */}
+          <ShortsDerivativeSection />
+          <SectionDivider />
+          {/* 最新新聞 */}
+          <LatestNewsSection
+            initialList={latestPosts.slice(startIndexOfLatestNewsSection)}
+          />
+        </main>
+      </div>
+      <NewsletterSubscription />
+      <Footer />
+    </>
   )
 }

--- a/app/section/layout.tsx
+++ b/app/section/layout.tsx
@@ -1,0 +1,21 @@
+import Header from '@/shared-components/header'
+import NewsletterSubscription from '@/shared-components/newsletter-subscription'
+import Footer from '@/shared-components/footer'
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <>
+      <Header />
+      {/* main content */}
+      <div className="flex w-full max-w-screen-lg shrink-0 grow flex-col">
+        {children}
+      </div>
+      <NewsletterSubscription />
+      <Footer />
+    </>
+  )
+}

--- a/app/tag/layout.tsx
+++ b/app/tag/layout.tsx
@@ -1,0 +1,21 @@
+import Header from '@/shared-components/header'
+import NewsletterSubscription from '@/shared-components/newsletter-subscription'
+import Footer from '@/shared-components/footer'
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return (
+    <>
+      <Header />
+      {/* main content */}
+      <div className="flex w-full max-w-screen-lg shrink-0 grow flex-col">
+        {children}
+      </div>
+      <NewsletterSubscription />
+      <Footer />
+    </>
+  )
+}


### PR DESCRIPTION
## Notable Changes
* 將 Root Layout 裡的 Header, NewsletterSubscription 和 Footer 下放到各路徑底下的 Layout

## Notes
* 目前有三種主要 Layout
  * 有 Header, NewsletterSubscription 和 Footer - 首頁、列表頁等
  * 有 Header, Footer - 文章頁、404、500
  * 完全客製 - 短影音頁
* 不採用 Router Group 的原因在與改動太多