### PR TITLE
chore: replace `eslint-plugin-filename-rules` with `eslint-plugin-check-file`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,14 +6,13 @@
     "plugin:prettier/recommended",
     "plugin:tailwindcss/recommended"
   ],
-  "plugins": ["filename-rules", "@typescript-eslint", "prettier"],
+  "plugins": ["check-file", "@typescript-eslint", "prettier"],
   "parserOptions": {
     "ecmaVersion": 2021,
     "sourceType": "module"
   },
   "rules": {
     "max-lines": ["error", { "max": 500 }],
-    "filename-rules/match": [2, "kebab-case"],
     "prettier/prettier": "error",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": "error",
@@ -25,6 +24,17 @@
     "tailwindcss/no-unnecessary-arbitrary-value": "error",
     "tailwindcss/no-custom-classname": ["error", {
       "whitelist": ["custom-swiper-pagination", "GTM-*"]
-    }]
+    }],
+    "check-file/folder-naming-convention": [
+      "error", {
+        "app/**/*": "NEXT_JS_APP_ROUTER_CASE",
+        "(constants|graphql|public|shared-components|types|utils)/**/*": "KEBAB_CASE"
+      }
+    ],
+    "check-file/filename-naming-convention": [
+      "error", {
+        "*/**/*": "KEBAB_CASE"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.1.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-filename-rules": "^1.3.1",
+    "eslint-plugin-check-file": "^2.8.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-tailwindcss": "^3.17.0",
     "husky": "^9.0.11",

--- a/shared-components/error/ui-404.tsx
+++ b/shared-components/error/ui-404.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable filename-rules/match */
 import { fetchPopularPost } from '@/app/actions-general'
 import ErrorAndNewsSection from './error-and-news-section'
 import PopularNewsSection from './popular-news-section'

--- a/shared-components/error/ui-500.tsx
+++ b/shared-components/error/ui-500.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable filename-rules/match */
 'use client'
 
 import { fetchPopularPost } from '@/app/actions-general'

--- a/shared-components/header-for-ui-500.tsx
+++ b/shared-components/header-for-ui-500.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable filename-rules/match */
 'use client'
 
 import { fetchFlashNews } from '@/app/actions'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2836,10 +2836,13 @@ eslint-module-utils@^2.7.4, eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-filename-rules@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-filename-rules/-/eslint-plugin-filename-rules-1.3.1.tgz#8fb769f2c19dc832b43c13d76c1442bca4a2f4a4"
-  integrity sha512-kBMxGFvK3QrRBHMurhFSNa+PFdszezVtBV6egg39TDzlj6D4jL3Xx6oyNjm5xE4C+TdQUBzWwymHJHBPyxOreA==
+eslint-plugin-check-file@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-check-file/-/eslint-plugin-check-file-2.8.0.tgz#6f93f28b25376ca9a7b0d741ca56a726d59f8db7"
+  integrity sha512-FvvafMTam2WJYH9uj+FuMxQ1y+7jY3Z6P9T4j2214cH0FBxNzTcmeCiGTj1Lxp3mI6kbbgsXvmgewvf+llKYyw==
+  dependencies:
+    is-glob "^4.0.3"
+    micromatch "^4.0.5"
 
 eslint-plugin-import@^2.28.1:
   version "2.29.1"


### PR DESCRIPTION
## Notable Changes
* 替換檔名檢查所使用的 ESLint 套件

## Notes
* `eslint-plugin-check-file` 在檢查 KEBAB CASE 上，支援數字 [參考](https://github.com/dukeluo/eslint-plugin-check-file/blob/5ae25c094131bd84912c5e13b0929c36eca3be3e/lib/constants/naming-convention.js#L24)