### PR TITLE
feat: add `/api/health` route

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+export const dynamic = 'force-dyanmic'
+
+export async function GET() {
+  return Response.json({ success: true, data: 'health check passed' })
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -54,7 +54,7 @@ const nextConfig = {
 
     /** @see https://paper.dropbox.com/doc/CDN-cache---CicA78_qhXGqWFqc4NC99FkAAg-9oJDty7PW69K9YuC40aic */
     return [
-      // default, 5 minutes
+      // default
       {
         source: '/:path*',
         headers: [
@@ -62,8 +62,20 @@ const nextConfig = {
             key: 'ETag',
             value: `"${process.env.GIT_HASH}"`,
           },
-          cacheControl5Min,
         ],
+      },
+      // 5 minutes
+      {
+        source: '/',
+        headers: [cacheControl5Min],
+      },
+      {
+        source: '/shorts/:path*',
+        headers: [cacheControl5Min],
+      },
+      {
+        source: '/topic/:path*',
+        headers: [cacheControl5Min],
       },
       // 30 minutes
       {


### PR DESCRIPTION
## Notable Chanages
* 增加 `/api/health` 給 service healthy check 使用
* 調整 cache-control header 設定，指名路徑與對應的 cache-control header，未被指定的路徑的 header 則使用 Next.js 原始的輸出結果。