### PR TITLE
feat: add temp gpt ads

### DIFF
--- a/app/_components/latest-news/post-list.tsx
+++ b/app/_components/latest-news/post-list.tsx
@@ -11,6 +11,8 @@ import {
   selectLatestPosts,
   selectLiveEvent,
 } from '@/redux/homepage/selector'
+import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
+import React from 'react'
 
 /** the amount of articles each time load-more is clicked  */
 const RENDER_PAGE_SIZE = 20
@@ -56,7 +58,12 @@ export default function PostList({ headerData }: PostListProps): ReactNode {
       }
     >
       {(posts: LatestPost[]) =>
-        posts.map((post) => <LatestNewsCard {...post} key={post.postId} />)
+        posts.map((post, i) => (
+          <React.Fragment key={post.postId}>
+            <LatestNewsCard {...post} />
+            {i == 2 && <MobileGptAd slotKey="mirrordaily_home_MW_336x280_HD" />}
+          </React.Fragment>
+        ))
       }
     </InfiniteScrollList>
   )

--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -6,6 +6,8 @@ import type { Metadata } from 'next'
 import { SITE_NAME } from '@/constants/misc'
 import { getCategoryPageUrl } from '@/utils/site-urls'
 import { getDefaultMetadata } from '@/utils/common'
+import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
+import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 
 type PageProps = { params: { slug: string } }
 
@@ -66,15 +68,41 @@ export default async function Page({ params }: PageProps) {
   }
 
   return (
-    <main className="mb-10 flex flex-col items-center md:mb-[72px] md:pt-5 lg:mb-[100px] lg:flex-row lg:items-start lg:gap-x-[128px] lg:px-9">
-      <ArticlesList
-        initialPosts={posts}
-        color={color}
-        name={name}
-        fetchMorePosts={fetchMorePosts}
+    <>
+      <div className="hidden h-[306px] lg:block">
+        <DesktopGptAd
+          slotKey="mirrordaily_home_PC_970x250_1"
+          customClasses="mt-5 mb-9 mx-auto"
+        />
+      </div>
+      <div className="block h-[352px] md:hidden">
+        <MobileGptAd
+          slotKey="mirrordaily_list_MW_336x280_HD"
+          customClasses="my-9 mx-auto"
+        />
+      </div>
+      <main className="mb-10 flex flex-col items-center md:mb-[72px] md:pt-5 lg:mb-[100px] lg:flex-row lg:items-start lg:gap-x-[128px] lg:px-9">
+        <ArticlesList
+          initialPosts={posts}
+          color={color}
+          name={name}
+          fetchMorePosts={fetchMorePosts}
+        />
+        <hr className="my-10 hidden w-[670px] border border-[#000928] md:block lg:hidden" />
+        <PopularNewsSection />
+        <MobileGptAd
+          slotKey="mirrordaily_list_MW_320x100_FIX"
+          customClasses="fixed bottom-0 auto z-[9999]"
+        />
+      </main>
+      <DesktopGptAd
+        slotKey="mirrordaily_list_970x250"
+        customClasses="mb-[80px] mx-auto"
       />
-      <hr className="my-10 hidden w-[670px] border border-[#000928] md:block lg:hidden" />
-      <PopularNewsSection />
-    </main>
+      <MobileGptAd
+        slotKey="mirrordaily_list_MW_336x280_FT"
+        customClasses="mt-8 mb-9 mx-auto z-[-1]"
+      />
+    </>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import ShortsDerivativeSection from './_components/shorts/derivative-section'
 import LatestNewsSection from './_components/latest-news/section'
 import Loading from './_components/loading'
 import { Suspense } from 'react'
+import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
 
 // add segment config to prevent data fetch during build
 export const dynamic = 'force-dynamic'
@@ -24,6 +25,12 @@ export default async function Home() {
       <Header />
       <div className="flex w-full max-w-screen-lg shrink-0 grow flex-col">
         <main className="flex w-full grow flex-col items-center justify-center">
+          <div className="hidden h-[306px] lg:block">
+            <DesktopGptAd
+              slotKey="mirrordaily_home_PC_970x250_1"
+              customClasses="mt-5 mb-9"
+            />
+          </div>
           <SectionDivider customClasses="hidden md:block lg:hidden" />
           {/* 編輯精選 */}
           <Suspense
@@ -35,6 +42,10 @@ export default async function Home() {
           >
             <EditorChoiceSection />
           </Suspense>
+          <DesktopGptAd
+            slotKey="mirrordaily_home_PC_728x90_1"
+            customClasses="my-7"
+          />
           <SectionDivider customClasses="lg:hidden" />
           {/* 即時新聞/熱門新聞（10則） */}
           <TopNewsSection headerData={headerData} />

--- a/app/section/[slug]/page.tsx
+++ b/app/section/[slug]/page.tsx
@@ -6,6 +6,8 @@ import type { Metadata } from 'next'
 import { SITE_NAME } from '@/constants/misc'
 import { getSectionPageUrl } from '@/utils/site-urls'
 import { getDefaultMetadata } from '@/utils/common'
+import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
+import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 
 type PageProps = { params: { slug: string } }
 
@@ -64,15 +66,41 @@ export default async function Page({
   }
 
   return (
-    <main className="mb-10 flex w-full flex-col items-center md:mb-[72px] md:pt-5 lg:mb-[100px] lg:flex-row lg:items-start lg:gap-x-[128px] lg:px-9">
-      <ArticlesList
-        initialPosts={posts}
-        color={color}
-        name={name}
-        fetchMorePosts={fetchMorePosts}
+    <>
+      <div className="hidden h-[306px] lg:block">
+        <DesktopGptAd
+          slotKey="mirrordaily_home_PC_970x250_1"
+          customClasses="mt-5 mb-9 mx-auto"
+        />
+      </div>
+      <div className="block h-[352px] md:hidden">
+        <MobileGptAd
+          slotKey="mirrordaily_list_MW_336x280_HD"
+          customClasses="my-9 mx-auto"
+        />
+      </div>
+      <main className="mb-10 flex w-full flex-col items-center md:mb-[72px] md:pt-5 lg:mb-[100px] lg:flex-row lg:items-start lg:gap-x-[128px] lg:px-9">
+        <ArticlesList
+          initialPosts={posts}
+          color={color}
+          name={name}
+          fetchMorePosts={fetchMorePosts}
+        />
+        <hr className="my-10 hidden w-[670px] border border-[#000928] md:block lg:hidden" />
+        <PopularNewsSection />
+        <MobileGptAd
+          slotKey="mirrordaily_list_MW_320x100_FIX"
+          customClasses="fixed bottom-0 auto z-[9999]"
+        />
+      </main>
+      <DesktopGptAd
+        slotKey="mirrordaily_list_970x250"
+        customClasses="my-[80px] mx-auto"
       />
-      <hr className="my-10 hidden w-[670px] border border-[#000928] md:block lg:hidden" />
-      <PopularNewsSection />
-    </main>
+      <MobileGptAd
+        slotKey="mirrordaily_list_MW_336x280_FT"
+        customClasses="mt-8 mb-9 mx-auto z-[-1]"
+      />
+    </>
   )
 }

--- a/app/story/[id]/page.tsx
+++ b/app/story/[id]/page.tsx
@@ -11,6 +11,8 @@ import AdultWarning from '../_components/adult-warning'
 // const MisoPageView = dynamic(() => import('@/app/_components/miso-pageview'), {
 //   ssr: false,
 // })
+import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
+import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 
 type PageProps = { params: { id: string } }
 
@@ -58,10 +60,26 @@ export default async function Page({ params }: PageProps) {
 
   return (
     <main className="flex flex-col items-center">
+      <div className="hidden h-[306px] lg:block">
+        <DesktopGptAd
+          slotKey="mirrordaily_home_PC_970x250_1"
+          customClasses="mt-5 mb-9"
+        />
+      </div>
+      <div className="block h-[352px] md:hidden">
+        <MobileGptAd
+          slotKey="mirrordaily_list_MW_336x280_HD"
+          customClasses="my-9"
+        />
+      </div>
       <hr className="hidden w-[680px] border border-[#000000] md:mb-9 md:block lg:mb-12 lg:mt-4 lg:w-[1128px]" />
       {/* <MisoPageView productIds={id} /> */}
       <ArticleSection {...postData} id={id} />
       <AdultWarning isAdult={postData.isAdult} />
+      <MobileGptAd
+        slotKey="mirrordaily_article_MW_320x100_ST"
+        customClasses="fixed bottom-0"
+      />
     </main>
   )
 }

--- a/app/story/_components/article-section.tsx
+++ b/app/story/_components/article-section.tsx
@@ -5,6 +5,8 @@ import Article from '../_components/article'
 import { fetchPopularPost, fetchLatestPost } from '@/app/actions-general'
 import { fetchRelatedPosts } from '../actions'
 import type { Post } from '@/types/story'
+import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
+import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 
 type Props = Post
 
@@ -23,7 +25,7 @@ export default async function ArticleSection({
     <section className="mb-[72px] flex w-full flex-col items-center md:mb-[76px] lg:mb-[92px] lg:flex-row lg:items-start lg:justify-center lg:gap-x-[104px]">
       <div className="max-w-screen-sm md:max-w-[600px] lg:max-w-screen-md">
         <HeroSection {...heroContent} />
-        <div className="mb-[60px]">
+        <div className="mb-12">
           <Article content={apiDataBrief} isBrief={true} />
           <Article content={apiData} isBrief={false} />
           <p className="mt-3 px-5 text-lg font-bold leading-loose text-[#212944] md:mt-8 md:px-0">
@@ -33,14 +35,29 @@ export default async function ArticleSection({
         {relatedPosts.length > 0 && <RelatedNewsSection posts={relatedPosts} />}
       </div>
 
-      <hr className="mb-12 mt-11 w-full max-w-[238px] border-[0.5px] border-[#7F8493] md:my-12 md:w-[588px] md:max-w-none lg:hidden" />
+      <MobileGptAd slotKey="mirrordaily_article_MW_336x280_AT3" />
 
-      <div className="flex flex-col gap-y-20 md:gap-y-12">
+      <hr className="my-8 w-full max-w-[238px] border-[0.5px] border-[#7F8493] md:my-12 md:w-[588px] md:max-w-none lg:hidden" />
+
+      <div className="flex flex-col items-center gap-y-[38px] md:gap-y-12">
         {latestPosts.length > 0 && (
-          <FeaturedNewsSection title="最新新聞" posts={latestPosts} />
+          <>
+            <DesktopGptAd
+              slotKey="mirrordaily_article_300x600_1"
+              customClasses="mb-[-20px]"
+            />
+            <FeaturedNewsSection title="最新新聞" posts={latestPosts} />
+          </>
         )}
         {popularPosts.length > 0 && (
-          <FeaturedNewsSection title="熱門新聞" posts={popularPosts} />
+          <>
+            <DesktopGptAd
+              slotKey="mirrordaily_article_PC_300x600_R2"
+              customClasses="mt-[-28px]"
+            />
+            <MobileGptAd slotKey="mirrordaily_article_MW_336x280_E1" />
+            <FeaturedNewsSection title="熱門新聞" posts={popularPosts} />
+          </>
         )}
       </div>
     </section>

--- a/constants/ad.ts
+++ b/constants/ad.ts
@@ -1,0 +1,100 @@
+// [GPT] Error in googletag.defineSlot: Cannot create slot /230117403/mirrordaily_970x250_1. Div element "div-gpt-ad-1744279281118-0" is already associated with another slot: /230117403/mirrordaily_970x250_1.
+
+export const adSlots = {
+  mirrordaily_home_PC_970x250_1: {
+    slotId: '/230117403/mirrordaily_970x250_1',
+    size: [970, 250],
+    adDivId: 'div-gpt-ad-1744279281118-0',
+    collapseEmptyDivs: false,
+  },
+  mirrordaily_list_970x250: {
+    slotId: '/230117403/mirrordaily_970x250_2',
+    size: [970, 250],
+    adDivId: 'div-gpt-ad-1744279311891-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_home_PC_728x90_1: {
+    slotId: '/230117403/mirrordaily_728x90',
+    size: [728, 90],
+    adDivId: 'div-gpt-ad-1744279337976-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_300x600_1: {
+    slotId: '/230117403/mirrordaily_300x600_1',
+    size: [300, 600],
+    adDivId: 'div-gpt-ad-1744279362483-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_PC_300x600_R2: {
+    slotId: '/230117403/mirrordaily_300x600_2',
+    size: [300, 600],
+    adDivId: 'div-gpt-ad-1744279386235-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_PC_640x390_AT1: {
+    slotId: '/230117403/mirrordaily_640x390',
+    size: [640, 390],
+    adDivId: 'div-gpt-ad-1744279415672-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_home_MW_336x280_HD: {
+    slotId: '/230117403/mirrordaily_336x280_1',
+    size: [336, 280],
+    adDivId: 'div-gpt-ad-1744279437652-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_list_MW_336x280_HD: {
+    slotId: '/230117403/mirrordaily_336x280_2',
+    size: [336, 280],
+    adDivId: 'div-gpt-ad-1744279460171-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_list_MW_336x280_FT: {
+    slotId: '/230117403/mirrordaily_336x280_3',
+    size: [336, 280],
+    adDivId: 'div-gpt-ad-1744279481157-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_MW_336x280_HD: {
+    slotId: '/230117403/mirrordaily_336x280_4',
+    size: [336, 280],
+    adDivId: 'div-gpt-ad-1744279509277-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_MW_336x280_AT1: {
+    slotId: '/230117403/mirrordaily_336x280_5',
+    size: [336, 280],
+    adDivId: 'div-gpt-ad-1744279528706-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_MW_336x280_AT2: {
+    slotId: '/230117403/mirrordaily_336x280_6',
+    size: [336, 280],
+    adDivId: 'div-gpt-ad-1744279549559-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_MW_336x280_AT3: {
+    slotId: '/230117403/mirrordaily_336x280_7',
+    size: [336, 280],
+    adDivId: 'div-gpt-ad-1744279571307-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_MW_336x280_E1: {
+    slotId: '/230117403/mirrordaily_336x280_8',
+    size: [336, 280],
+    adDivId: 'div-gpt-ad-1744279592402-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_list_MW_320x100_FIX: {
+    slotId: '/230117403/mirrordaily_320x100_1',
+    size: [320, 100],
+    adDivId: 'div-gpt-ad-1744279612959-0',
+    collapseEmptyDivs: true,
+  },
+  mirrordaily_article_MW_320x100_ST: {
+    slotId: '/230117403/mirrordaily_320x100_2',
+    size: [320, 100],
+    adDivId: 'div-gpt-ad-1744279632834-0',
+    collapseEmptyDivs: true,
+  },
+} as const

--- a/shared-components/api-data-renderer/renderer.tsx
+++ b/shared-components/api-data-renderer/renderer.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import AudioBlock from './block-renderer/audio-block'
 import BackgroundImageBlock from './block-renderer/background-image-block'
 import BackgroundVideoBlock from './block-renderer/background-video-block'
@@ -13,12 +14,14 @@ import { OrderListBlock, UnorderListBlock } from './block-renderer/list-block'
 import SideIndexBlock from './block-renderer/side-index-block'
 import SlideshowBlock from './block-renderer/slideshow-block'
 import TableBlock from './block-renderer/table-block'
-import type { ApiData } from './block-renderer/types'
+import type { ApiData, ApiDataBlock } from './block-renderer/types'
 import UnstyledBlock from './block-renderer/unstyled-block'
 import VideoBlock from './block-renderer/video-block'
 import YoutubeBlock from './block-renderer/youtube-block'
 import { ApiDataBlockType } from './types'
 import { getOrganizationFromSourceCustomId } from './utils'
+import { DesktopGptAd } from '../gpt-ad/desktop-gpt-ad'
+import { MobileGptAd } from '../gpt-ad/mobile-gpt-ad'
 
 export type { ApiData } from './block-renderer/types'
 
@@ -34,153 +37,153 @@ export default function ApiDataRenderer({
   const organization =
     getOrganizationFromSourceCustomId(sourceCustomId) || 'mirror-media'
 
+  const getApiDataBlockJsx = (apiDataBlock: ApiDataBlock) => {
+    switch (apiDataBlock.type) {
+      case ApiDataBlockType.Unstyled:
+        return (
+          <UnstyledBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+        )
+      case ApiDataBlockType.HeaderTwo:
+        return (
+          <Header2Block
+            key={apiDataBlock.id}
+            organization={organization}
+            apiDataBlock={apiDataBlock}
+          />
+        )
+      case ApiDataBlockType.HeaderThree:
+        return (
+          <Header3Block
+            key={apiDataBlock.id}
+            organization={organization}
+            apiDataBlock={apiDataBlock}
+          />
+        )
+      case ApiDataBlockType.Blockquote:
+        return (
+          <BlockquoteBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+        )
+      case ApiDataBlockType.UnorderList:
+        return (
+          <UnorderListBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+        )
+      case ApiDataBlockType.OrderList:
+        return (
+          <OrderListBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+        )
+      case ApiDataBlockType.CodeBlock:
+        return <CodeBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+      case ApiDataBlockType.Divider:
+        return <DividerBlock key={apiDataBlock.id} />
+      case ApiDataBlockType.Image:
+        return <ImageBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+      case ApiDataBlockType.Video:
+      case ApiDataBlockType.VideoV2:
+        return (
+          <VideoBlock
+            key={apiDataBlock.id}
+            organization={organization}
+            apiDataBlock={apiDataBlock}
+          />
+        )
+      case ApiDataBlockType.Slideshow:
+      case ApiDataBlockType.SlideshowV2:
+        return (
+          <SlideshowBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+        )
+      case ApiDataBlockType.Infobox:
+        return (
+          <InfoboxBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+        )
+      case ApiDataBlockType.Audio:
+      case ApiDataBlockType.AudioV2:
+        return (
+          <AudioBlock
+            key={apiDataBlock.id}
+            organization={organization}
+            apiDataBlock={apiDataBlock}
+          />
+        )
+      case ApiDataBlockType.Table:
+        return <TableBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+      case ApiDataBlockType.ColorBox:
+        return (
+          <ColorBoxBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+        )
+      case ApiDataBlockType.BackgroundImage:
+        return (
+          <BackgroundImageBlock
+            key={apiDataBlock.id}
+            organization={organization}
+            apiDataBlock={apiDataBlock}
+          />
+        )
+      case ApiDataBlockType.BackgroundVideo:
+        return (
+          <BackgroundVideoBlock
+            key={apiDataBlock.id}
+            organization={organization}
+            apiDataBlock={apiDataBlock}
+          />
+        )
+      case ApiDataBlockType.RelatedPost:
+        return
+      case ApiDataBlockType.SideIndex:
+        return (
+          <SideIndexBlock
+            key={apiDataBlock.id}
+            organization={organization}
+            apiDataBlock={apiDataBlock}
+          />
+        )
+      case ApiDataBlockType.Youtube:
+        return (
+          <YoutubeBlock
+            key={apiDataBlock.id}
+            organization={organization}
+            apiDataBlock={apiDataBlock}
+          />
+        )
+      case ApiDataBlockType.EmbedCode:
+        return (
+          <EmbedCodeBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
+        )
+
+      default: {
+        const exhaustiveCheck: never = apiDataBlock
+        console.error('unhandled apiData type', exhaustiveCheck)
+        return null
+      }
+    }
+  }
+
   return (
     <article className={`${isBrief ? 'brief' : 'content'} story-renderer`}>
-      {apiData.map((apiDataBlock) => {
-        switch (apiDataBlock.type) {
-          case ApiDataBlockType.Unstyled:
-            return (
-              <UnstyledBlock
-                key={apiDataBlock.id}
-                apiDataBlock={apiDataBlock}
+      {apiData.map((apiDataBlock, i) => {
+        const apiDataBlockJsx = getApiDataBlockJsx(apiDataBlock)
+        return (
+          <React.Fragment key={i}>
+            {!isBrief && i === 1 && (
+              <MobileGptAd
+                slotKey="mirrordaily_article_MW_336x280_AT1"
+                customClasses="mx-auto"
               />
-            )
-          case ApiDataBlockType.HeaderTwo:
-            return (
-              <Header2Block
-                key={apiDataBlock.id}
-                organization={organization}
-                apiDataBlock={apiDataBlock}
+            )}
+            {!isBrief && i === 3 && (
+              <DesktopGptAd
+                slotKey="mirrordaily_article_PC_640x390_AT1"
+                customClasses="mx-auto"
               />
-            )
-          case ApiDataBlockType.HeaderThree:
-            return (
-              <Header3Block
-                key={apiDataBlock.id}
-                organization={organization}
-                apiDataBlock={apiDataBlock}
+            )}
+            {!isBrief && i === 5 && (
+              <MobileGptAd
+                slotKey="mirrordaily_article_MW_336x280_AT2"
+                customClasses="mx-auto"
               />
-            )
-          case ApiDataBlockType.Blockquote:
-            return (
-              <BlockquoteBlock
-                key={apiDataBlock.id}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.UnorderList:
-            return (
-              <UnorderListBlock
-                key={apiDataBlock.id}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.OrderList:
-            return (
-              <OrderListBlock
-                key={apiDataBlock.id}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.CodeBlock:
-            return (
-              <CodeBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
-            )
-          case ApiDataBlockType.Divider:
-            return <DividerBlock key={apiDataBlock.id} />
-          case ApiDataBlockType.Image:
-            return (
-              <ImageBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
-            )
-          case ApiDataBlockType.Video:
-          case ApiDataBlockType.VideoV2:
-            return (
-              <VideoBlock
-                key={apiDataBlock.id}
-                organization={organization}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.Slideshow:
-          case ApiDataBlockType.SlideshowV2:
-            return (
-              <SlideshowBlock
-                key={apiDataBlock.id}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.Infobox:
-            return (
-              <InfoboxBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
-            )
-          case ApiDataBlockType.Audio:
-          case ApiDataBlockType.AudioV2:
-            return (
-              <AudioBlock
-                key={apiDataBlock.id}
-                organization={organization}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.Table:
-            return (
-              <TableBlock key={apiDataBlock.id} apiDataBlock={apiDataBlock} />
-            )
-          case ApiDataBlockType.ColorBox:
-            return (
-              <ColorBoxBlock
-                key={apiDataBlock.id}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.BackgroundImage:
-            return (
-              <BackgroundImageBlock
-                key={apiDataBlock.id}
-                organization={organization}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.BackgroundVideo:
-            return (
-              <BackgroundVideoBlock
-                key={apiDataBlock.id}
-                organization={organization}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.RelatedPost:
-            return
-          case ApiDataBlockType.SideIndex:
-            return (
-              <SideIndexBlock
-                key={apiDataBlock.id}
-                organization={organization}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.Youtube:
-            return (
-              <YoutubeBlock
-                key={apiDataBlock.id}
-                organization={organization}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-          case ApiDataBlockType.EmbedCode:
-            return (
-              <EmbedCodeBlock
-                key={apiDataBlock.id}
-                apiDataBlock={apiDataBlock}
-              />
-            )
-
-          default: {
-            const exhaustiveCheck: never = apiDataBlock
-            console.error('unhandled apiData type', exhaustiveCheck)
-            return null
-          }
-        }
+            )}
+            {apiDataBlockJsx}
+          </React.Fragment>
+        )
       })}
     </article>
   )

--- a/shared-components/gpt-ad/base-gpt-ad.tsx
+++ b/shared-components/gpt-ad/base-gpt-ad.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import Script from 'next/script'
+import { ENV } from '@/constants/config'
+import { ENVIRONMENT } from '@/constants/misc'
+import { adSlots } from '@/constants/ad'
+import { twMerge } from 'tailwind-merge'
+
+export type AdSlotKey = keyof typeof adSlots
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    googletag?: any
+  }
+}
+
+const isDebugMode = ENV === ENVIRONMENT.LOCAL || ENV === ENVIRONMENT.DEVELOPMENT
+
+export default function BaseGptAd({
+  slotKey,
+  customClasses,
+}: {
+  slotKey: AdSlotKey
+  customClasses: string
+}) {
+  const isInitialed = useRef(false)
+  const { slotId, size, adDivId, collapseEmptyDivs } = adSlots[slotKey]
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || isInitialed.current) return
+
+    window.googletag = window.googletag || { cmd: [] }
+
+    window.googletag.cmd.push(function () {
+      if (isDebugMode) {
+        console.log(
+          `[GPT-AD DEBUG] Registering ad slot: ${slotId}, divId: ${adDivId}`
+        )
+      }
+
+      window.googletag
+        .defineSlot(slotId, size, adDivId)
+        .addService(window.googletag.pubads())
+
+      window.googletag.pubads().enableSingleRequest()
+
+      if (collapseEmptyDivs && !isDebugMode) {
+        window.googletag.pubads().collapseEmptyDivs()
+      }
+
+      window.googletag.enableServices()
+      window.googletag.display(adDivId)
+    })
+    isInitialed.current = true
+  }, [slotId, adDivId, size, collapseEmptyDivs])
+
+  return (
+    <>
+      <Script
+        id="gpt-sdk"
+        strategy="afterInteractive"
+        src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
+      />
+      <div
+        id={adDivId}
+        style={{
+          width: size[0],
+          height: size[1],
+        }}
+        className={twMerge(
+          `${isDebugMode ? `relative border-2 border-dashed border-red-500` : ''}`,
+          customClasses
+        )}
+      >
+        {isDebugMode && (
+          <span className="absolute left-0 top-0 z-[9999] bg-red-500 px-1 py-0.5 text-[12px] text-white">
+            {slotId}
+          </span>
+        )}
+      </div>
+    </>
+  )
+}

--- a/shared-components/gpt-ad/desktop-gpt-ad.tsx
+++ b/shared-components/gpt-ad/desktop-gpt-ad.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { AdSlotKey } from './base-gpt-ad'
+import BaseGptAd from './base-gpt-ad'
+import { getTailwindConfigBreakpointNumber } from '@/utils/tailwind'
+
+export function DesktopGptAd({
+  slotKey,
+  customClasses = '',
+}: {
+  slotKey: AdSlotKey
+  customClasses?: string
+}) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    const check = () =>
+      setShow(window.innerWidth >= getTailwindConfigBreakpointNumber('lg'))
+
+    check()
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
+
+  return show ? (
+    <BaseGptAd slotKey={slotKey} customClasses={customClasses} />
+  ) : null
+}

--- a/shared-components/gpt-ad/mobile-gpt-ad.tsx
+++ b/shared-components/gpt-ad/mobile-gpt-ad.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { AdSlotKey } from './base-gpt-ad'
+import BaseGptAd from './base-gpt-ad'
+import { getTailwindConfigBreakpointNumber } from '@/utils/tailwind'
+
+export function MobileGptAd({
+  slotKey,
+  customClasses = '',
+}: {
+  slotKey: AdSlotKey
+  customClasses?: string
+}) {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    const check = () =>
+      setShow(window.innerWidth < getTailwindConfigBreakpointNumber('md'))
+
+    check()
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
+
+  return show ? (
+    <BaseGptAd slotKey={slotKey} customClasses={customClasses} />
+  ) : null
+}


### PR DESCRIPTION
# Feature

Add temporarily gpt ads for homepage, story, section and category pages.

Ads script [doc](https://docs.google.com/spreadsheets/d/1XuQgJUYlcxAbUX6oLQEKeoLxJPG3VNDTGM0SAxnZYqs/edit?gid=0#gid=0)
Figma [design](https://www.figma.com/design/zjxDdw6TQAXLRW5lL1ydC9/%E9%8F%A1%E5%A0%B1-Web?node-id=5991-19140&p=f&t=YQ8tirhrEGFZeJkZ-0)

## BaseGptAd 

- Combine the script for Head and Body to prepare the ad slot in useEffect.
- Add red dash border for dev and local env to simplify debugging.

## Mobile and Desktop GptAd

- Instead of putting mobile and desktop ads in the same component, split them and only show the ad in the right window width could be easier to control. 
- For the first screen placeholder, simply put a div outside the component to hold the space for ads to show.