### PR TITLE
feat: add post name and post brief to highlight item

### DIFF
--- a/app/_components/top-news/highlight-item.tsx
+++ b/app/_components/top-news/highlight-item.tsx
@@ -4,6 +4,28 @@ import type { PickupItemInTopNewsSection } from '@/types/homepage'
 import CustomImage from '@/shared-components/custom-image'
 import ReactPlayer from 'react-player/lazy'
 
+// 標題與簡介
+const PostTitleAndBrief = ({
+  postName,
+  postBrief,
+}: {
+  postName: PickupItemInTopNewsSection['postName']
+  postBrief?: PickupItemInTopNewsSection['postBrief']
+}) => {
+  return (
+    <>
+      <p className="mt-4 line-clamp-3 text-base font-medium leading-none text-[#000928] group-hover/highlight-item:text-[#575D71] group-active/highlight-item:text-[#575D71] md:mt-2 md:line-clamp-2 lg:mt-2 lg:text-xl lg:font-bold">
+        {postName}
+      </p>
+      {postBrief && (
+        <p className="mt-3 hidden text-sm font-normal leading-normal text-[#68666D] md:line-clamp-3 lg:text-base lg:font-bold">
+          {postBrief}
+        </p>
+      )}
+    </>
+  )
+}
+
 export default function HighlightItem({
   heroImage,
   postName,
@@ -29,6 +51,7 @@ export default function HighlightItem({
             },
           }}
         />
+        <PostTitleAndBrief postName={postName} postBrief={postBrief} />
       </div>
     )
   }
@@ -52,14 +75,7 @@ export default function HighlightItem({
           }}
         />
       </div>
-      <p className="mt-4 line-clamp-3 text-base font-medium leading-none text-[#000928] group-hover/highlight-item:text-[#575D71] group-active/highlight-item:text-[#575D71] md:mt-2 md:line-clamp-2 lg:mt-2 lg:text-xl lg:font-bold">
-        {postName}
-      </p>
-      {postBrief && (
-        <p className="mt-3 hidden text-sm font-normal leading-normal text-[#68666D] md:line-clamp-3 lg:text-base lg:font-bold">
-          {postBrief}
-        </p>
-      )}
+      <PostTitleAndBrief postName={postName} postBrief={postBrief} />
     </a>
   )
 }


### PR DESCRIPTION
## Additions

- A component for postName and postBrief.


## Changes

- Add postName and postBrief to live highlight item.

- 375px
![Screenshot 2025-05-08 at 4 00 46 PM](https://github.com/user-attachments/assets/21b72faa-bc72-4a87-a84f-693e8f4b2632)

- 1440px
![Screenshot 2025-05-08 at 4 01 16 PM](https://github.com/user-attachments/assets/1b426488-5492-4ee1-8b9d-2d85a26e375b)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210181688431493