### PR TITLE
feat: remove swiper slideTo

### DIFF
--- a/app/_components/shorts/list.tsx
+++ b/app/_components/shorts/list.tsx
@@ -83,7 +83,6 @@ export default function ShortsList({ items, customClass = '' }: Props) {
               key={index}
               isActive={isIntersecting && activeIndex === index}
               onPlay={() => {
-                swiperRef.current?.swiper.slideTo(index)
                 setActiveIndex(index)
               }}
               onPause={() => {


### PR DESCRIPTION
prevent shorts jitter

## Changes

- remove `swiper.slideTo` function

## Screenshots

- _mobile_
![Screen Recording 2025-05-09 at 12 06 22 PM](https://github.com/user-attachments/assets/0d475a9b-399a-4c79-8509-3285daca6987)

- _1440px (desktop)_
![Screen Recording 2025-05-09 at 12 04 18 PM](https://github.com/user-attachments/assets/d02e8abf-79f2-4159-85c6-7fbf4045aee7)


## Todos

* [ ] 讓第一個或最後一個的影片不會被裁切
* [ ] hover時可以讓影片顯示全部的component

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210095159068539