### PR TITLE
feat: add external choices to editor choices

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -15,7 +15,10 @@ import {
 } from '@/constants/config'
 import { createErrorLogger, getTraceObject } from '@/utils/log/common'
 import { fetchGQLData } from '@/utils/graphql'
-import type { GetLiveEventForHomepageQuery } from '@/graphql/__generated__/graphql'
+import type {
+  GetLiveEventForHomepageQuery,
+  ImageDataFragment,
+} from '@/graphql/__generated__/graphql'
 import {
   GetEditorChoicesDocument,
   GetLiveEventForHomepageDocument,
@@ -153,23 +156,35 @@ const transformEditorChoices = (
       index
     ) => {
       const postId = rawPost?.id ?? ''
-      const external = externalRawPost?.id ?? ''
+      const externalId = externalRawPost?.id ?? ''
+
+      /**除了choiceexternal, choices 編輯精選也可以設定首圖，如果有設定的話會優先使用。 */
+      const getHeroImageByPostType = (
+        imageParam:
+          | Pick<ImageDataFragment, 'resized' | 'resizedWebp'>
+          | string
+          | null
+          | undefined
+      ) => {
+        const editorChoiceHeroImage = heroImage ? getHeroImage(heroImage) : null
+        return editorChoiceHeroImage || getHeroImage(imageParam)
+      }
 
       if (outlink) {
         return {
-          postId: `${index}-${postId}`,
-          postName: rawPost?.title ?? '',
+          postId: '',
+          postName: '',
           link: outlink,
-          heroImage: getHeroImage(heroImage),
+          heroImage: getHeroImageByPostType(heroImage),
         }
       }
 
-      if (external) {
+      if (externalId) {
         return {
-          postId: `${index}-${postId}`,
+          postId: `${index}-${externalId}`,
           postName: externalRawPost?.title ?? '',
-          link: getExternalPageUrl(external),
-          heroImage: getHeroImage(heroImage),
+          link: getExternalPageUrl(externalId),
+          heroImage: getHeroImageByPostType(externalRawPost?.thumb),
         }
       }
 
@@ -177,7 +192,7 @@ const transformEditorChoices = (
         postId: `${index}-${postId}`,
         postName: rawPost?.title ?? '',
         link: getStoryPageUrl(postId),
-        heroImage: getHeroImage(rawPost?.heroImage),
+        heroImage: getHeroImageByPostType(rawPost?.heroImage),
       }
     }
   )

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -146,25 +146,41 @@ const transformEditorChoices = (
 ): EditorChoice[] => {
   if (!rawData) return []
 
-  return rawData.map(({ outlink, heroImage, choices: rawPost }, index) => {
-    const postId = rawPost?.id ?? ''
+  // NOTE: outlink, external, choices 只會擇一出現，因此總共有三種情況
+  return rawData.map(
+    (
+      { outlink, heroImage, choices: rawPost, choiceexternal: externalRawPost },
+      index
+    ) => {
+      const postId = rawPost?.id ?? ''
+      const external = externalRawPost?.id ?? ''
 
-    if (outlink) {
+      if (outlink) {
+        return {
+          postId: `${index}-${postId}`,
+          postName: rawPost?.title ?? '',
+          link: outlink,
+          heroImage: getHeroImage(heroImage),
+        }
+      }
+
+      if (external) {
+        return {
+          postId: `${index}-${postId}`,
+          postName: externalRawPost?.title ?? '',
+          link: getExternalPageUrl(external),
+          heroImage: getHeroImage(heroImage),
+        }
+      }
+
       return {
         postId: `${index}-${postId}`,
         postName: rawPost?.title ?? '',
-        link: outlink,
-        heroImage: getHeroImage(heroImage),
+        link: getStoryPageUrl(postId),
+        heroImage: getHeroImage(rawPost?.heroImage),
       }
     }
-
-    return {
-      postId: `${index}-${postId}`,
-      postName: rawPost?.title ?? '',
-      link: getStoryPageUrl(postId),
-      heroImage: getHeroImage(rawPost?.heroImage),
-    }
-  })
+  )
 }
 
 export const fetchEditorChoices = async (): Promise<

--- a/utils/data-schema.ts
+++ b/utils/data-schema.ts
@@ -106,6 +106,14 @@ export const editorChoiceSchenma = z.object({
       heroImage: true,
     })
     .nullish(),
+  choiceexternal: z
+    .object({
+      id: z.string(),
+      title: z.string(),
+      slug: z.string(),
+      thumb: z.string(),
+    })
+    .nullish(),
 })
 
 export const topicsSchema = z.object({


### PR DESCRIPTION
編輯精選新增外部文章
原本有`outlink`, `choices`,新增 `externalChoices`

# Changes
- new zod type
- add cond in transformEditorChoices

# Note
- outlink data
    - 外部連結預設會提供heroImage所以只需要兩者
```json
{
  "outlink": "https://www.readr.tw/post/2989",
  "heroImage": null,
  "choices": null,
  "order": 39,
  "choiceexternal": null
},
```

- choice data
```json
{
  "outlink": "",
  "heroImage": null,
  "choices": {
  "title": "測測測測",
  "id": "133",
  "heroImage": null
},
"order": 555,
"choiceexternal": null
}
```

- external
    - heroImage 要拿 `thumb`
```json
"choiceexternal": {
  "id": "1347063",
  "slug": "",
  "thumb": "https://v3-statics.mirrormedia.mg/images/057faef1-4c69-4424-9232-129e5a1c8dab-w1600.jpg",
  "title": "裕隆集團籃球隊史第二度三連霸 嚴陳莉蓮樂剪冠軍籃網"
}
```
# Screen Shots

- 375px (external)
![Screenshot 2025-05-13 at 2 17 30 PM](https://github.com/user-attachments/assets/30739d09-a8a4-4eb6-b56f-5ee006de6f6a)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210192799018650