### PR TITLE
fix: add onReachEnd and onReachBeginning to correct the state

### DIFF
--- a/app/_components/shorts/list.tsx
+++ b/app/_components/shorts/list.tsx
@@ -74,6 +74,12 @@ export default function ShortsList({ items, customClass = '' }: Props) {
           setSwiperIsEnd(swiper.isEnd)
           setActiveIndex(swiper.realIndex)
         }}
+        onReachEnd={() => {
+          setSwiperIsEnd(true)
+        }}
+        onReachBeginning={() => {
+          setSwiperIsBeginning(true)
+        }}
         className="shorts-swiper-in-homepage"
       >
         {items.map((item, index) => (


### PR DESCRIPTION
# Changes
- [Swiper Doc](https://swiperjs.com/swiper-api#events)
- use `onReachEnd` and `onReachBeginning` to help detect .

# Screen Shots
![螢幕錄影 2025-05-13 下午3 50 39](https://github.com/user-attachments/assets/86557e9f-1ffa-41ed-99d1-5b54854d84c4)
