### PR TITLE
fix: update swiper navigation buttons

### DIFF
--- a/app/_components/editor-choice/swiper-component.tsx
+++ b/app/_components/editor-choice/swiper-component.tsx
@@ -10,7 +10,6 @@ import 'swiper/css/navigation'
 import type { EditorChoice } from '@/types/homepage'
 import Image from 'next/image'
 import { useState } from 'react'
-import { useWindowSize } from 'usehooks-ts'
 
 type Props = {
   list: EditorChoice[]
@@ -20,8 +19,7 @@ export default function SwiperComponent({ list }: Props) {
   const swiperNavigationButtonSize = { width: 48, height: 48 }
   const [isSwiperBeginning, setIsBeginning] = useState(true)
   const [isSwiperEnd, setIsSwiperEnd] = useState(false)
-  const { width } = useWindowSize()
-  const isDesktop = width >= 1200
+
   return (
     <div className="relative">
       <Swiper
@@ -81,32 +79,25 @@ export default function SwiperComponent({ list }: Props) {
           )
         })}
         <div className="custom-swiper-pagination" />
-
         <button
-          className="custom-swiper-navigation-next"
-          style={{
-            display: !isSwiperEnd && isDesktop ? 'block' : 'none',
-          }}
-        >
-          {/* Use sr-only to hide an element visually without hiding it from screen readers */}
-          <span className="sr-only">Next Slide</span>
-          <Image
-            src="icons/swiper/swiper-next.svg"
-            alt="slide-next"
-            {...swiperNavigationButtonSize}
-          />
-        </button>
-        <button
-          className="custom-swiper-navigation-prev hidden lg:block"
-          style={{
-            display: !isSwiperBeginning && isDesktop ? 'block' : 'none',
-          }}
+          className={`custom-swiper-navigation-prev ${isSwiperBeginning ? 'first' : ''}`}
         >
           {/* Use sr-only to hide an element visually without hiding it from screen readers */}
           <span className="sr-only">Previous Slide</span>
           <Image
             src="icons/swiper/swiper-prev.svg"
             alt="slide-prev"
+            {...swiperNavigationButtonSize}
+          />
+        </button>
+        <button
+          className={`custom-swiper-navigation-next ${isSwiperEnd ? 'last' : ''}`}
+        >
+          {/* Use sr-only to hide an element visually without hiding it from screen readers */}
+          <span className="sr-only">Next Slide</span>
+          <Image
+            src="icons/swiper/swiper-next.svg"
+            alt="slide-next"
             {...swiperNavigationButtonSize}
           />
         </button>

--- a/shared-styles/global.css
+++ b/shared-styles/global.css
@@ -60,6 +60,13 @@
     .custom-swiper-navigation-prev {
       @apply left-3 lg:left-6;
     }
+
+    .custom-swiper-navigation-prev.first {
+      @apply invisible;
+    }
+    .custom-swiper-navigation-next.last {
+      @apply invisible;
+    }
   }
   .header-submit-button {
     @apply mt-8 hidden h-6 w-20 items-center justify-center rounded-[29px] bg-[#ff5457] text-[15px] font-normal leading-none text-white first:ml-0 lg:flex;


### PR DESCRIPTION
fix: update swiper navigation buttons to improve visibility and accessibility

## Changes

- Updated Swiper navigation buttons to improve visibility and accessibility. The buttons are now always present, with styling to hide them when they are not usable (e.g., the "previous" button on the first slide).  CSS classes `first` and `last` are added to `custom-swiper-navigation-prev` and `custom-swiper-navigation-next` respectively to control visibility.
- Removed `useWindowSize` hook and related desktop-specific logic for button display. The buttons' visibility is now controlled solely by Swiper's state and CSS classes.
- Modified CSS to use the `invisible` class for hiding buttons instead of `display: none`, ensuring they remain in the DOM for accessibility.

## Testing

- Visually tested the Swiper component to ensure navigation buttons appear and disappear correctly based on the current slide.


## Screenshots

### 手機版維持沒有按鈕
<img width="366" alt="Screenshot 2025-05-20 at 11 25 10 AM" src="https://github.com/user-attachments/assets/93fe2e4a-3027-47dd-a55e-856b13efd705" />

### 桌機版
![Screen Recording 2025-05-20 at 11 26 14 AM](https://github.com/user-attachments/assets/8dbd64e7-1844-45c4-854e-1440330e6d14)
