### PR TITLE
fix: live section remove old logic

### DIFF
--- a/app/_components/live/latest-video-list.tsx
+++ b/app/_components/live/latest-video-list.tsx
@@ -1,7 +1,6 @@
 'use client'
 import type { LatestVideos } from '@/types/common'
-import ReactPlayer from 'react-player/lazy'
-import Loading from '../loading'
+import Image from 'next/image'
 
 export default function LatestVideoList({
   latestVideos,
@@ -12,29 +11,11 @@ export default function LatestVideoList({
     <div className="flex grow flex-col items-center lg:items-start lg:justify-end lg:gap-8">
       {latestVideos.map((video) => (
         <div key={video.id} className="flex gap-5">
-          <div className="md:tablet-live-video flex aspect-[330/220] w-full shrink-0 grow lg:h-[100px] lg:w-[180px]">
-            {/**   NOTE: preload: 'none', 會造成太大的影片沒有辦法顯示（測試的時候影片長度一小時）
-             * 遇到的情境：
-             * 1. onReady 不會被觸發
-             * 2. onError 不會被觸發
-             */}
-            <ReactPlayer
-              url={video.fileUrl}
-              width="100%"
-              height="100%"
-              muted={true}
-              playing={false}
-              playsinline={true}
-              controls={true}
-              fallback={<Loading />}
-              onError={(error) => console.error('Video load error:', error)}
-              config={{
-                file: {
-                  attributes: {
-                    'aria-label': `Video: ${video.title}`,
-                  },
-                },
-              }}
+          <div className="md:tablet-live-video relative flex aspect-[330/220] w-full shrink-0 grow lg:h-[100px] lg:w-[180px]">
+            <Image
+              src={video.poster || '/images-next/default-image.png'}
+              fill
+              alt={`${video.title}`}
             />
           </div>
           <div className="flex flex-col gap-1">

--- a/app/_components/top-news/section.tsx
+++ b/app/_components/top-news/section.tsx
@@ -39,22 +39,18 @@ export default function TopNewsSection({ headerData }: Props) {
   const postData: PostData = useMemo(() => {
     let latestList: PostData['Latest'] = [undefined]
 
-    if (liveEvent) {
-      latestList = [liveEvent, ...latestPosts.slice(0, 9)]
-    } else {
-      const first = latestPosts[0]
+    const first = latestPosts[0]
 
-      if (first) {
-        latestList = [
-          {
-            postName: first.postName,
-            postBrief: first.postBrief,
-            heroImage: first.heroImage,
-            link: first.link,
-          },
-          ...latestPosts.slice(1, 10),
-        ]
-      }
+    if (first) {
+      latestList = [
+        {
+          postName: first.postName,
+          postBrief: first.postBrief,
+          heroImage: first.heroImage,
+          link: first.link,
+        },
+        ...latestPosts.slice(1, 10),
+      ]
     }
 
     let hotList: PostData['Hot'] = [undefined]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -132,6 +132,10 @@ const nextConfig = {
         hostname: 'storage.googleapis.com',
         pathname: '/statics-dev.mirrordaily.news/ads_image/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'statics-dev.mirrordaily.news',
+      },
     ],
   },
 }


### PR DESCRIPTION
Refactor video list and top news section, update image domains

## Additions

- Added `statics-dev.mirrordaily.news` to `next.config.mjs` image remote patterns.

## Removals

- Removed `ReactPlayer` and `Loading` components from `app/_components/live/latest-video-list.tsx`.
- Removed `liveEvent` related logic from `app/_components/top-news/section.tsx`.

## Changes

- Refactored `app/_components/live/latest-video-list.tsx` to use `next/image` for displaying video thumbnails instead of `ReactPlayer`.
- Simplified logic in `app/_components/top-news/section.tsx` to always use `latestPosts` for the main highlighted post.

## Testing

- Manually tested the video list to ensure images are displayed correctly.
- Manually tested the top news section to ensure the correct posts are displayed.


## Screenshots

<img width="906" alt="Screenshot 2025-05-26 at 11 52 21 AM" src="https://github.com/user-attachments/assets/3d0c382a-96c1-4a4e-a881-d4388657805b" />
<img width="828" alt="Screenshot 2025-05-26 at 11 52 36 AM" src="https://github.com/user-attachments/assets/aa9df9ea-1d92-4f8e-8a8f-82681dfe8406" />

