### PR TITLE
fix: ensure Meta Pixel noscript tag matches Meta's requirements

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -95,15 +95,11 @@ export default function RootLayout({
             `,
           }}
         />
-        <noscript>
-          <img
-            height="1"
-            width="1"
-            //@ts-expect-error: meta pixel default
-            style="display: 'none'"
-            src="https://www.facebook.com/tr?id=1223816476113313&ev=PageView&noscript=1"
-          />
-        </noscript>
+        <noscript
+          dangerouslySetInnerHTML={{
+            __html: `<img height="1" width="1" style="display: 'none'" src="https://www.facebook.com/tr?id=1223816476113313&ev=PageView&noscript=1" />`,
+          }}
+        />
         {/* End Meta Pixel Code */}
         <noscript
           dangerouslySetInnerHTML={{


### PR DESCRIPTION
## Summary
This pull request updates the Meta Pixel `<noscript>` implementation in `app/layout.tsx` to ensure it matches Meta's official requirements and avoids React/Next.js build errors.

## Details
- Uses `dangerouslySetInnerHTML` to inject the exact `<img>` tag required by Meta for the `<noscript>` fallback, ensuring the `style` attribute is rendered as a string (not an object), as Meta expects.
- This approach bypasses JSX/React's style prop validation, which would otherwise cause build errors.
- No functional changes to tracking, but this guarantees compliance and future maintainability.

## Motivation
- Fixes build errors caused by React's strict style prop validation.
- Ensures the output HTML is exactly as Meta's documentation specifies, which is important for analytics and compliance.
