### PR TITLE
feat:  point CPBL game info card link to schedule page

### DIFF
--- a/app/_components/sports/game-info-card.tsx
+++ b/app/_components/sports/game-info-card.tsx
@@ -72,7 +72,8 @@ export default function GameInfoCard({
     }
     return formatGameTime(dayjs(startTime))
   }
-  const leagueSiteUrl = league === 'cpbl' ? CPBL_SITE_URL : TPBL_SITE_URL
+  const leagueSiteUrl =
+    league === 'cpbl' ? `${CPBL_SITE_URL}/schedule` : `${TPBL_SITE_URL}`
 
   return (
     <Link


### PR DESCRIPTION
根據需求調整，將 CPBL 賽事資訊卡的超連結從 CPBL 首頁改成 https://www.cpbl.com.tw/schedule