### PR TITLE
feat: add post name for live event and adjust related styling and layout

### DIFF
--- a/app/_components/live/latest-video-list.tsx
+++ b/app/_components/live/latest-video-list.tsx
@@ -18,7 +18,7 @@ export default function LatestVideoList({
   }
 
   return (
-    <div className="flex grow flex-col items-center lg:items-start lg:justify-start lg:gap-8">
+    <div className="flex grow flex-col items-center lg:items-start lg:justify-start lg:gap-12">
       {latestVideos.map((video) => (
         <a
           key={video.id}

--- a/app/_components/live/section.tsx
+++ b/app/_components/live/section.tsx
@@ -27,15 +27,20 @@ export default async function LiveSection() {
   return (
     <section className="section-in-homepage items-center py-7 lg:flex lg:items-start">
       <div className="flex grow flex-col justify-start lg:w-[640px]">
-        <p className="mb-6 w-full text-center text-lg font-bold leading-none text-mirror-blue-700 lg:text-start">
+        <p className="mb-4 w-full text-center text-lg font-bold leading-none text-mirror-blue-700 md:mb-5 lg:mb-4 lg:text-start">
           直播區
         </p>
-        <div className="lg:mr-11 lg:h-[364px] lg:border-r lg:border-r-black lg:pr-11">
-          <LiveSectionMain {...liveEventData} />
+        <div className="lg:mr-9 lg:border-r lg:border-r-primary-800 lg:pr-9">
+          <div className="lg:h-[360px]">
+            <LiveSectionMain {...liveEventData} />
+          </div>
+          <div className="mt-4 w-full text-justify text-base/[1.2] font-medium text-primary-800 md:mx-auto md:mt-5 md:w-[504px] lg:mx-0 lg:mt-4 lg:w-[600px] lg:text-xl/[1.2] lg:font-bold">
+            {liveEventData.postName}
+          </div>
         </div>
       </div>
-      <div className="hidden lg:flex lg:w-[400px] lg:flex-col lg:justify-start lg:self-stretch">
-        <p className="mb-6 w-full text-center text-lg font-bold leading-none text-mirror-blue-700 lg:text-start">
+      <div className="hidden lg:flex lg:w-[455px] lg:flex-col lg:justify-start lg:self-stretch">
+        <p className="mb-4 w-full text-center text-lg font-bold leading-none text-mirror-blue-700 lg:text-start">
           最新影音
         </p>
         <LatestVideoList latestVideos={latestVideosData} />


### PR DESCRIPTION
- 在直播區的影片下方新增影片標題，同時設定對應的 RWD 樣式
- 調整直播區與最新影音列表的空間佈局，讓兩區等高，並讓中間分隔線兩側留白對稱

#
#### 相關連結
1. 設計稿
https://www.figma.com/design/zjxDdw6TQAXLRW5lL1ydC9/%E9%8F%A1%E5%A0%B1-Web?node-id=1-2&t=DHrAhXaBzJjUbr3k-1

2. 任務卡
https://app.asana.com/1/614399484723017/project/1210077071799813/task/1210724706076119?focus=true