### PR TITLE
feat(tag): noindex pages with fewer than 4 posts to improve SEO

### DIFF
--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -21,6 +21,22 @@ export async function generateMetadata({
     notFound()
   }
 
+  const { totalAmount } = await fetchTagPosts({
+    take: 0,
+    skip: 0,
+    slug,
+    withAmount: true,
+  })
+
+  const robotsObj =
+    (totalAmount ?? 0) < 4
+      ? {
+          robots: {
+            index: false,
+            follow: false,
+          },
+        }
+      : {}
   const defaultMetadata = getDefaultMetadata()
 
   const title = `${tagInfo.name} - ${SITE_NAME}`
@@ -29,6 +45,7 @@ export async function generateMetadata({
     {},
     {
       ...defaultMetadata,
+      ...robotsObj,
       title,
       openGraph: {
         ...(defaultMetadata.openGraph ?? {}),

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -28,7 +28,8 @@ export async function generateMetadata({
     withAmount: true,
   })
 
-  const robotsObj =
+  const defaultMetadata = getDefaultMetadata()
+  const robotsMetaData =
     (totalAmount ?? 0) < 4
       ? {
           robots: {
@@ -37,7 +38,6 @@ export async function generateMetadata({
           },
         }
       : {}
-  const defaultMetadata = getDefaultMetadata()
 
   const title = `${tagInfo.name} - ${SITE_NAME}`
 
@@ -45,7 +45,7 @@ export async function generateMetadata({
     {},
     {
       ...defaultMetadata,
-      ...robotsObj,
+      ...robotsMetaData,
       title,
       openGraph: {
         ...(defaultMetadata.openGraph ?? {}),


### PR DESCRIPTION
為文章少於 4 則的 tag 頁加上` <meta name="robots" content="noindex, nofollow">`，防止搜尋引擎將該頁編入搜尋結果，同時取消追蹤使用者在此頁開啟的連結

任務卡：
https://app.asana.com/1/614399484723017/project/1210828396831826/task/1210683252222105?focus=true