### PR TITLE
feat: display section instead of category for news items

### DIFF
--- a/app/_components/top-news/list-item.tsx
+++ b/app/_components/top-news/list-item.tsx
@@ -3,8 +3,8 @@ import type { CSSProperties } from 'react'
 
 type Props = Pick<
   ItemInTopNewsSection,
-  | 'categoryColor'
-  | 'categoryName'
+  | 'sectionName'
+  | 'sectionColor'
   | 'postId'
   | 'postName'
   | 'publishedDate'
@@ -12,8 +12,8 @@ type Props = Pick<
 >
 
 export default function ListItem({
-  categoryName,
-  categoryColor,
+  sectionName,
+  sectionColor,
   publishedDate,
   postName,
   link,
@@ -22,13 +22,13 @@ export default function ListItem({
     <div className="[&:not(:last-child)]:border-b [&:not(:last-child)]:border-[#CCCED4] [&:not(:last-child)]:pb-3 md:[&:not(:last-child)]:pb-2">
       <div className={`flex items-center`}>
         <span
-          style={{ backgroundColor: categoryColor }}
+          style={{ backgroundColor: sectionColor }}
           className="inline-block h-5 rounded-xl px-2 py-1 text-xs font-bold leading-[12px] tracking-[0.5px] text-[#F6F6FB]"
         >
-          {categoryName || 'Video'}
+          {sectionName || 'Video'}
         </span>
         <time
-          style={{ color: categoryColor }}
+          style={{ color: sectionColor }}
           className="ml-2 text-sm font-light leading-normal tracking-[0.5px] md:ml-3"
         >
           {publishedDate}
@@ -40,7 +40,7 @@ export default function ListItem({
         className="mt-[6px] line-clamp-2 h-[42px] break-all text-base font-medium leading-[21px] text-[#575D71] hover-or-active:text-[color:var(--custom-active-color)] md:h-10 md:text-sm md:font-normal md:leading-[20px] lg:line-clamp-1 lg:h-auto lg:text-base lg:font-medium lg:leading-normal"
         style={
           {
-            '--custom-active-color': categoryColor,
+            '--custom-active-color': sectionColor,
           } as CSSProperties
         }
       >

--- a/types/homepage.ts
+++ b/types/homepage.ts
@@ -3,6 +3,7 @@ import type { LatestPost } from './common'
 export type ItemInTopNewsSection = Pick<
   LatestPost,
   | 'sectionColor'
+  | 'sectionName'
   | 'categoryName'
   | 'categoryColor'
   | 'postName'

--- a/utils/post.ts
+++ b/utils/post.ts
@@ -14,7 +14,7 @@ const hasExternalLink = (
   return isValidUrl(redirect)
 }
 
-type CategoryConfig = {
+type SectionConfig = {
   name: string
   color: string
 }
@@ -22,15 +22,15 @@ type CategoryConfig = {
 const getSectionConfig = (
   rawPosts: z.infer<typeof rawLatestPostSchema>,
   headerData: HeaderData[]
-): CategoryConfig => {
+): SectionConfig => {
   const { partner, sections } = rawPosts
 
   if (typeof partner === 'string') {
-    const categoryName = sections[0]?.name || DEFAULT_SECTION_NAME
-    const color = getSectionColor(headerData, sections[0]?.slug)
+    const sectionName = sections[1]?.name || DEFAULT_SECTION_NAME
+    const color = getSectionColor(headerData, sections[1]?.slug)
 
     return {
-      name: categoryName,
+      name: sectionName,
       color,
     }
   } else {
@@ -87,11 +87,11 @@ const transformRawPopularPost = (
     sectionsInInputOrder: sections,
     categories,
   } = rawPosts
-  const sectionColor = getSectionColor(headerData, sections[0]?.slug)
+  const sectionColor = getSectionColor(headerData, sections[1]?.slug)
   const categoryColor = getCategoryColor(headerData, categories[0]?.slug)
 
   return {
-    sectionName: sections[0]?.name ?? DEFAULT_SECTION_NAME,
+    sectionName: sections[1]?.name ?? DEFAULT_SECTION_NAME,
     sectionColor,
     categoryName: categories[0]?.name ?? DEFAULT_SECTION_NAME,
     categoryColor,


### PR DESCRIPTION
- 首頁即時新聞和熱門新聞標籤：從原本的小分類標籤改拿即時標籤以外的大分類標籤，同時調整對應的標籤顏色和 hover 在該標籤所屬的文章標題後的顯示顏色
- 首頁最新新聞標籤：從原本以即時標籤為主的大分類標籤，改拿即時標籤以外的大分類標籤

**相關資料**
即時新聞（前 10 篇）／最新新聞（從第 11 篇開始拿）共用同份 JSON：
https://storage.googleapis.com/statics-dev.mirrordaily.news/json/latest_posts01.json?xy=1111

熱門新聞的 JSON：
https://storage.googleapis.com/statics-dev.mirrordaily.news/json/popular.json

**任務卡**
https://app.asana.com/1/614399484723017/project/1210828396831826/task/1210447586402778?focus=true