### PR TITLE
feat: collapse top ad container when ad blocker is detected

### DIFF
--- a/app/_components/top-ad-section.tsx
+++ b/app/_components/top-ad-section.tsx
@@ -4,30 +4,11 @@ import useAdBlockDetector from '@/hooks/use-ad-block-detector'
 import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
 import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 
-type TopAdSectionProps = {
-  isStagingOrProd: boolean
-}
-
-export default function TopAdSection({ isStagingOrProd }: TopAdSectionProps) {
+export default function TopAdSection() {
   const { isAdBlockerActive } = useAdBlockDetector()
 
-  if (isAdBlockerActive) return null // Don't render ads if ad blocker is active
-  return isStagingOrProd ? (
-    <>
-      <div className="hidden min-h-[306px] lg:block">
-        <DesktopGptAd
-          slotKey="mirrordaily_home_PC_970x250_1"
-          customClasses="mt-5 mb-9"
-        />
-      </div>
-      <div className="block min-h-[286px] md:hidden">
-        <MobileGptAd
-          slotKey="mirrordaily_list_MW_336x280_HD"
-          customClasses="my-9 mx-auto"
-        />
-      </div>
-    </>
-  ) : (
+  if (isAdBlockerActive) return null
+  return (
     <>
       <div className="hidden min-h-[306px] lg:flex lg:items-center">
         <DesktopGptAd

--- a/app/_components/top-ad-section.tsx
+++ b/app/_components/top-ad-section.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import useAdBlockDetector from '@/hooks/use-ad-block-detector'
+import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
+import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
+
+type TopAdSectionProps = {
+  isStagingOrProd: boolean
+}
+
+export default function TopAdSection({ isStagingOrProd }: TopAdSectionProps) {
+  const { isAdBlockerActive } = useAdBlockDetector()
+
+  if (isAdBlockerActive) return null // Don't render ads if ad blocker is active
+  return isStagingOrProd ? (
+    <>
+      <div className="hidden min-h-[306px] lg:block">
+        <DesktopGptAd
+          slotKey="mirrordaily_home_PC_970x250_1"
+          customClasses="mt-5 mb-9"
+        />
+      </div>
+      <div className="block min-h-[286px] md:hidden">
+        <MobileGptAd
+          slotKey="mirrordaily_list_MW_336x280_HD"
+          customClasses="my-9 mx-auto"
+        />
+      </div>
+    </>
+  ) : (
+    <>
+      <div className="hidden min-h-[306px] lg:flex lg:items-center">
+        <DesktopGptAd
+          slotKey="mirrordaily_home_PC_970x250_top"
+          customClasses="mt-5 mb-9"
+        />
+      </div>
+      <div className="block min-h-[286px] md:hidden">
+        <MobileGptAd
+          slotKey="mirrordaily_home_MW_300x250_top"
+          customClasses="mb-9 mx-auto"
+        />
+      </div>
+    </>
+  )
+}

--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -10,9 +10,9 @@ import type { Metadata } from 'next'
 import { SITE_NAME } from '@/constants/misc'
 import { getCategoryPageUrl } from '@/utils/site-urls'
 import { getDefaultMetadata } from '@/utils/common'
-import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
 import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 import { PAGE_SIZE, JSON_ITEMS_COUNT } from '@/constants/category'
+import ListPageTopAd from '@/shared-components/top-ads/list-page-top-ad'
 
 type PageProps = { params: { slug: string } }
 
@@ -89,20 +89,7 @@ export default async function Page({ params }: PageProps) {
 
   return (
     <>
-      <div className="hidden min-h-[306px] lg:flex lg:items-center">
-        <DesktopGptAd
-          slotKey="mirrordaily_section_PC_970x250_top"
-          customClasses="mt-5 mb-9 mx-auto"
-          pageKey={slug}
-        />
-      </div>
-      <div className="block min-h-[286px] md:hidden">
-        <MobileGptAd
-          slotKey="mirrordaily_section_MW_300x250_top"
-          customClasses="mb-9 mx-auto"
-          pageKey={slug}
-        />
-      </div>
+      <ListPageTopAd slug={slug} />
 
       <main className="mb-10 flex flex-col items-center md:mb-[72px] md:pt-5 lg:mb-[100px] lg:flex-row lg:items-start lg:gap-x-[128px] lg:px-9">
         <ArticlesList

--- a/app/external/[id]/page.tsx
+++ b/app/external/[id]/page.tsx
@@ -13,6 +13,7 @@ import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
 import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 import MisoPageView from '@/shared-components/miso-pageview'
 import DableWidget from '@/shared-components/dable-widget'
+import ArticlePageTopAd from '@/shared-components/top-ads/article-page-top-ad'
 
 type PageProps = { params: { id: string } }
 
@@ -82,18 +83,7 @@ export default async function Page({ params }: PageProps) {
   return (
     <main className="flex flex-col items-center">
       <MisoPageView productIds={`external_${id}`} />
-      <div className="hidden min-h-[306px] lg:flex lg:items-center">
-        <DesktopGptAd
-          slotKey="mirrordaily_article_PC_970x250_top"
-          customClasses="mt-5 mb-9"
-        />
-      </div>
-      <div className="block min-h-[286px] md:hidden">
-        <MobileGptAd
-          slotKey="mirrordaily_article_MW_300x250_top"
-          customClasses="mb-9"
-        />
-      </div>
+      <ArticlePageTopAd />
       <hr className="hidden w-[680px] border border-[#000000] md:mb-9 md:block lg:mb-12 lg:mt-4 lg:w-[1128px]" />
       <section className="mb-[72px] mt-5 flex flex-col items-center md:mb-[76px] md:mt-9 lg:mb-[92px] lg:mt-[6px] lg:flex-row lg:items-start lg:justify-center lg:gap-x-[104px]">
         <div className="max-w-screen-sm md:max-w-[600px] lg:max-w-screen-md">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 import SportsSection from './_components/sports/section'
 import LiveSection from './_components/live/section'
 import ElectionRecall from './_components/election-recall'
-
+import TopAdSection from './_components/top-ad-section'
 // add segment config to prevent data fetch during build
 export const dynamic = 'force-dynamic'
 
@@ -33,18 +33,7 @@ export default async function Home() {
       <Header />
       <div className="flex w-full max-w-screen-lg shrink-0 grow flex-col">
         <main className="flex w-full grow flex-col items-center justify-center">
-          <div className="hidden min-h-[306px] lg:flex lg:items-center">
-            <DesktopGptAd
-              slotKey="mirrordaily_home_PC_970x250_top"
-              customClasses="mt-5 mb-9"
-            />
-          </div>
-          <div className="block min-h-[286px] md:hidden">
-            <MobileGptAd
-              slotKey="mirrordaily_home_MW_300x250_top"
-              customClasses="mb-9 mx-auto"
-            />
-          </div>
+          <TopAdSection />
 
           {/* 選舉罷免 */}
           <ElectionRecall />

--- a/app/section/[slug]/page.tsx
+++ b/app/section/[slug]/page.tsx
@@ -10,9 +10,9 @@ import type { Metadata } from 'next'
 import { SITE_NAME } from '@/constants/misc'
 import { getSectionPageUrl } from '@/utils/site-urls'
 import { getDefaultMetadata } from '@/utils/common'
-import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
 import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 import { PAGE_SIZE, JSON_ITEMS_COUNT } from '@/constants/section'
+import ListPageTopAd from '@/shared-components/top-ads/list-page-top-ad'
 
 type PageProps = { params: { slug: string } }
 
@@ -91,20 +91,7 @@ export default async function Page({
 
   return (
     <>
-      <div className="hidden min-h-[306px] lg:flex lg:items-center">
-        <DesktopGptAd
-          slotKey="mirrordaily_section_PC_970x250_top"
-          customClasses="mt-5 mb-9 mx-auto"
-          pageKey={slug}
-        />
-      </div>
-      <div className="block min-h-[286px] md:hidden">
-        <MobileGptAd
-          slotKey="mirrordaily_section_MW_300x250_top"
-          customClasses="mb-9 mx-auto"
-          pageKey={slug}
-        />
-      </div>
+      <ListPageTopAd slug={slug} />
 
       <main className="mb-10 flex flex-col items-center md:mb-[72px] md:pt-5 lg:mb-[100px] lg:flex-row lg:items-start lg:gap-x-[128px] lg:px-9">
         <ArticlesList

--- a/app/story/[id]/page.tsx
+++ b/app/story/[id]/page.tsx
@@ -9,10 +9,9 @@ import { getDefaultMetadata } from '@/utils/common'
 import { Suspense } from 'react'
 import PageLogger from '@/shared-components/page-logger'
 import AdultWarning from '../_components/adult-warning'
-import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
-import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
 import MisoPageView from '@/shared-components/miso-pageview'
 import { ENV } from '@/constants/config'
+import ArticlePageTopAd from '@/shared-components/top-ads/article-page-top-ad'
 
 type PageProps = { params: { id: string } }
 
@@ -89,19 +88,7 @@ export default async function Page({ params }: PageProps) {
         <PageLogger extra={extra} />
       </Suspense>
       <main className="flex flex-col items-center">
-        <div className="hidden min-h-[306px] lg:flex lg:items-center">
-          <DesktopGptAd
-            slotKey="mirrordaily_article_PC_970x250_top"
-            customClasses="mt-5 mb-9"
-          />
-        </div>
-
-        <div className="block min-h-[286px] md:hidden">
-          <MobileGptAd
-            slotKey="mirrordaily_article_MW_300x250_top"
-            customClasses="mb-9"
-          />
-        </div>
+        <ArticlePageTopAd />
         <hr className="hidden w-[680px] border border-[#000000] md:mb-9 md:block lg:mb-12 lg:mt-4 lg:w-[1128px]" />
         <MisoPageView productIds={`story_${id}`} />
         <ArticleSection {...postData} id={id} />

--- a/hooks/use-ad-block-detector.ts
+++ b/hooks/use-ad-block-detector.ts
@@ -2,38 +2,40 @@
 
 import { useState, useEffect } from 'react'
 
+const BLOCKED_URLS = [
+  'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js',
+  'https://static.doubleclick.net/instream/ad_status.js',
+  'https://imasdk.googleapis.com/js/sdkloader/ima3.js',
+]
+
 export default function useAdBlockDetector() {
   const [isAdBlockerActive, setIsAdBlockerActive] = useState(false)
 
   useEffect(() => {
-    const bait = document.createElement('div')
-    bait.className = 'ad-banner text-ad ad-container advertisement'
-    bait.style.height = '1px'
-    bait.style.width = '1px'
-    bait.style.position = 'absolute'
-    bait.style.top = '-9999px'
-    bait.style.left = '-9999px'
-    bait.style.pointerEvents = 'none' // Ensure it's not interactive.
-    bait.setAttribute('aria-hidden', 'true') // Hide from screen readers.
+    const checkAdBlocker = async () => {
+      try {
+        await Promise.all(
+          BLOCKED_URLS.map((url) =>
+            fetch(new Request(url), {
+              method: 'HEAD',
+              mode: 'no-cors',
+              cache: 'no-store',
+            })
+          )
+        )
 
-    document.body.appendChild(bait)
-
-    const timer = setTimeout(() => {
-      if (bait.offsetHeight === 0) {
+        setIsAdBlockerActive(false)
+      } catch (error) {
         setIsAdBlockerActive(true)
       }
+    }
 
-      if (document.body.contains(bait)) {
-        document.body.removeChild(bait)
-      }
-    }, 150)
+    const checkTimeout = setTimeout(() => {
+      checkAdBlocker()
+    }, 50)
 
     return () => {
-      clearTimeout(timer)
-
-      if (document.body.contains(bait)) {
-        document.body.removeChild(bait)
-      }
+      clearTimeout(checkTimeout)
     }
   }, [])
 

--- a/hooks/use-ad-block-detector.ts
+++ b/hooks/use-ad-block-detector.ts
@@ -1,0 +1,41 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export default function useAdBlockDetector() {
+  const [isAdBlockerActive, setIsAdBlockerActive] = useState(false)
+
+  useEffect(() => {
+    const bait = document.createElement('div')
+    bait.className = 'ad-banner text-ad ad-container advertisement'
+    bait.style.height = '1px'
+    bait.style.width = '1px'
+    bait.style.position = 'absolute'
+    bait.style.top = '-9999px'
+    bait.style.left = '-9999px'
+    bait.style.pointerEvents = 'none' // Ensure it's not interactive.
+    bait.setAttribute('aria-hidden', 'true') // Hide from screen readers.
+
+    document.body.appendChild(bait)
+
+    const timer = setTimeout(() => {
+      if (bait.offsetHeight === 0) {
+        setIsAdBlockerActive(true)
+      }
+
+      if (document.body.contains(bait)) {
+        document.body.removeChild(bait)
+      }
+    }, 150)
+
+    return () => {
+      clearTimeout(timer)
+
+      if (document.body.contains(bait)) {
+        document.body.removeChild(bait)
+      }
+    }
+  }, [])
+
+  return { isAdBlockerActive }
+}

--- a/shared-components/top-ads/article-page-top-ad.tsx
+++ b/shared-components/top-ads/article-page-top-ad.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import useAdBlockDetector from '@/hooks/use-ad-block-detector'
+import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
+import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
+
+export default function ArticlePageTopAd() {
+  const { isAdBlockerActive } = useAdBlockDetector()
+
+  if (isAdBlockerActive) return null
+  return (
+    <>
+      <div className="hidden min-h-[306px] lg:flex lg:items-center">
+        <DesktopGptAd
+          slotKey="mirrordaily_article_PC_970x250_top"
+          customClasses="mt-5 mb-9"
+        />
+      </div>
+      <div className="block min-h-[286px] md:hidden">
+        <MobileGptAd
+          slotKey="mirrordaily_article_MW_300x250_top"
+          customClasses="mb-9"
+        />
+      </div>
+    </>
+  )
+}

--- a/shared-components/top-ads/list-page-top-ad.tsx
+++ b/shared-components/top-ads/list-page-top-ad.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import useAdBlockDetector from '@/hooks/use-ad-block-detector'
+import { DesktopGptAd } from '@/shared-components/gpt-ad/desktop-gpt-ad'
+import { MobileGptAd } from '@/shared-components/gpt-ad/mobile-gpt-ad'
+
+export default function ListPageTopAd({ slug }: { slug: string }) {
+  const { isAdBlockerActive } = useAdBlockDetector()
+
+  if (isAdBlockerActive) return null
+  return (
+    <>
+      <div className="hidden min-h-[306px] lg:flex lg:items-center">
+        <DesktopGptAd
+          slotKey="mirrordaily_section_PC_970x250_top"
+          customClasses="mt-5 mb-9 mx-auto"
+          pageKey={slug}
+        />
+      </div>
+      <div className="block min-h-[286px] md:hidden">
+        <MobileGptAd
+          slotKey="mirrordaily_section_MW_300x250_top"
+          customClasses="mb-9 mx-auto"
+          pageKey={slug}
+        />
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
- 新增 `useAdBlockDetector`：用於偵測使用者是否開啟阻擋廣告的瀏覽器插件。若使用者開啟插件，我們向廣告網域發出的網路請求將會被攔截並拋出錯誤，此時可透過 `setIsAdBlockerActive` 將 `isAdBlockerActive` 的值設為`true`，代表使用者開啟插件，反之亦然。`isAdBlockerActive` 的目的是為了控制包裹廣告元件的那個設有最小高度的 div 元素的顯示與否，廣告元件本身會被插件隱藏，無需透過`isAdBlockerActive` 控制。
- 承上，`useAdBlockDetector` 中放的3個 URL 都是知名廣告網域的資源，因為可以阻擋廣告的瀏覽器插件會檢查使用者送出的網路請求是否和廣告服務有關，如果有關就會攔截請求並拋出錯誤，所以我們在這邊故意向3個廣告網域的資源發出請求，看看會不會被攔截，來推測使用者有沒有開啟阻擋廣告的瀏覽器插件。
- 鏡報的成果廣告目前共放置於以下 5 個頁面：首頁、catergory 頁、section 頁、story 頁、external 頁。因這些頁面的 page.tsx 皆採 SSR，為了使用 hook ，故將各頁最上方的廣告元件相關程式碼獨立抽出成客戶端元件。
- 考量元件重用性，原本打算將五個頁面最上方的廣告元件整合成一個客戶端元件，但因各頁面廣告元件結構不同，整合成一個會降低可讀性和可維護性，故將結構相同的最上方廣告程式碼獨立成客戶端元件： 將 catergory 頁和 section 頁的最上方廣告元件程式碼獨立成 `ListPageTopAd`，將 story 頁和 external 頁的最上方廣告元件程式碼獨立成 `ArticlePageTopAd`，首頁自成`TopAdSection`。

**任務卡**
https://app.asana.com/1/614399484723017/project/1210828396831826/task/1210683253501415?focus=true