### PR TITLE
feat(story): Add news_keywords meta tag for SEO

### DIFF
--- a/app/story/[id]/page.tsx
+++ b/app/story/[id]/page.tsx
@@ -30,6 +30,11 @@ export async function generateMetadata({
   const title = `${postData.title} - ${SITE_NAME}`
   const description = getFirstParagraphFromApiData(postData.apiDataBrief) || ''
   const image = postData.postMainImage?.resized?.original || IMAGE_PATH
+  const tags = postData.tags.map((tag) => tag.name)
+  const algoTags = postData.algoTags.map((tag) => tag.name)
+  const keywords = [postData.title, SITE_NAME, '新聞', ...tags, ...algoTags]
+    .filter(Boolean)
+    .join(', ')
   const other: Record<string, string> = {
     'article:published_time': new Date(postData.publishedTime).toISOString(),
     'article:section': postData.sectionName || 'UnCategorized',
@@ -38,6 +43,7 @@ export async function generateMetadata({
       : 'Unknown Author',
     'dable:item_id': postData.id,
     'section:color': postData.sectionColor,
+    news_keywords: keywords,
   }
 
   if (ENV !== 'prod') {


### PR DESCRIPTION
- 在文章頁新增 ​​`<meta name="news_keywords" content="news, keywords" />`：此 meta tag 有助於 Google News 精準地理解與分類該篇新聞，提高對該分類新聞或關鍵字有興趣的讀者的曝光。
- 然而經查詢發現，Google 已在多年前停止支援此 meta tag，意即加上此 mata tag 將無助於新聞分類和排名，請 PM 將此發現回報給鏡報，鏡報還是希望可以加上，故加上。

**相關連結與資料**
1. 任務卡
https://app.asana.com/1/614399484723017/project/1210934602843435/task/1210853955290511?focus=true

2. Google 官方文件：Google 支援的 meta 標記和屬性
https://developers.google.com/search/docs/crawling-indexing/special-tags?hl=zh-tw

3. Google drops support for meta news keywords tag
https://searchengineland.com/google-drops-support-meta-news-keywords-tag-292493

4. A newly hatched way to tag your news articles
https://news.googleblog.com/2012/09/a-newly-hatched-way-to-tag-your-news.html

5. Google 宣布新聞版元關鍵字標籤
https://clickshq.com/2012/09/26/google-announces-meta-keyword-tags-for-news/