### PR TITLE
feat: guard Cloud Logging with ADC and update sports news source and diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ certificates
 # editor
 .cursor/
 .vscode/
+
+# gemini
+.gemini
+GEMINI.md

--- a/app/actions-logging.ts
+++ b/app/actions-logging.ts
@@ -11,6 +11,21 @@ import utc from 'dayjs/plugin/utc'
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
+/**
+ * Determine whether the current runtime has Application Default Credentials (ADC).
+ * ADC is available only when running on Google Cloud managed environments
+ * (Cloud Run, GCE, or GKE) with a Service Account attached.
+ * This guard prevents unexpected authentication errors in local environments.
+ */
+function canUseCloudLogging(): boolean {
+  return (
+    // Cloud Run
+    !!process.env.K_SERVICE ||
+    // GCE / GKE
+    !!process.env.GCE_METADATA_HOST
+  )
+}
+
 export async function logPageView({
   referrer,
   screenSize,
@@ -20,6 +35,8 @@ export async function logPageView({
   screenSize: { width: number; height: number }
   extra?: Record<string, unknown>
 }) {
+  if (!canUseCloudLogging()) return
+
   const eventType = 'page-view'
   const logName = `${GCP_PROJECT_ID}-${ENV}-web-${eventType}`
   const logging = new Logging({ projectId: GCP_PROJECT_ID })
@@ -83,6 +100,8 @@ export async function logVideoView({
   screenSize: { width: number; height: number }
   extra?: Record<string, unknown>
 }) {
+  if (!canUseCloudLogging()) return
+
   const eventType = 'video-view'
   const logName = `${GCP_PROJECT_ID}-${ENV}-web-${eventType}`
   const logging = new Logging({ projectId: GCP_PROJECT_ID })

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -445,9 +445,9 @@ const transformSportsNewsImage = (
 const transformLatestSportsNews = (
   rawData: z.infer<typeof latestSportsNewsSchema> | undefined
 ): LatestSportsNewsData[] => {
-  if (!rawData || !rawData.category) return []
+  if (!rawData || !rawData.section) return []
 
-  return rawData.category.items.map((item) => {
+  const convertedData = rawData.section.items.map((item) => {
     if (item.type === 'external') {
       const { id, title, publishedDate, thumb } = item
       return {
@@ -468,6 +468,8 @@ const transformLatestSportsNews = (
       heroImage: transformSportsNewsImage(heroImage, og_image),
     }
   })
+
+  return convertedData.splice(0, 4)
 }
 
 export const fetchLatestSportsNews = async (): Promise<
@@ -477,10 +479,12 @@ export const fetchLatestSportsNews = async (): Promise<
     'Error occurs while fetching latest sports news',
     getTraceObject()
   )
-  const schema = z.promise(latestSportsNewsSchema)
   try {
     const resp = await fetch(URL_STATIC_LATEST_SPORTS_NEWS)
-    const parseResult = await schema.safeParse(resp.json())
+    const json = await resp.json()
+
+    const parseResult = latestSportsNewsSchema.safeParse(json)
+
     if (!parseResult.success) {
       errorLogger(parseResult.error)
       return []

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -447,7 +447,7 @@ const transformLatestSportsNews = (
 ): LatestSportsNewsData[] => {
   if (!rawData || !rawData.section) return []
 
-  const convertedData = rawData.section.items.map((item) => {
+  const convertedData = rawData.section.items?.map((item) => {
     if (item.type === 'external') {
       const { id, title, publishedDate, thumb } = item
       return {

--- a/constants/config.ts
+++ b/constants/config.ts
@@ -82,7 +82,7 @@ const URL_STATIC_TOPIC = `${JSON_FILE_PATH}/topics.json${TIMESTAMP_FOR_CACHE}`
 const URL_STATIC_LATEST_SHORTS = `${JSON_FILE_PATH}/latest-shorts-hp.json${TIMESTAMP_FOR_CACHE}`
 const URL_STATIC_LATEST_VIDEOS = `${JSON_FILE_PATH}/youtube/UCeN_H2EG1U6StWZhlBEWjjg_latest.json${TIMESTAMP_FOR_CACHE}`
 const URL_STATIC_WEATHER = `${JSON_FILE_PATH}/weather.json${TIMESTAMP_FOR_CACHE}`
-const URL_STATIC_LATEST_SPORTS_NEWS = `${JSON_FILE_PATH}/latest/latest_content_category_sport_1.json${TIMESTAMP_FOR_CACHE}`
+const URL_STATIC_LATEST_SPORTS_NEWS = `${JSON_FILE_PATH}/latest/latest_content_section_sport_1.json`
 const URL_STATIC_SPORTS_EVENTS = `${JSON_FILE_PATH}/sports_schedule.json${TIMESTAMP_FOR_CACHE}`
 // shorts listing page
 const URL_STATIC_NEWS_SHORTSPAGE = `${JSON_FILE_PATH}/shortpage_news`

--- a/graphql/__generated__/graphql.ts
+++ b/graphql/__generated__/graphql.ts
@@ -2372,6 +2372,7 @@ export type Post = {
   preview?: Maybe<Scalars['JSON']['output']>
   publishedDate?: Maybe<Scalars['DateTime']['output']>
   publishedDateString?: Maybe<Scalars['String']['output']>
+  pv?: Maybe<Scalars['Int']['output']>
   redirect?: Maybe<Scalars['String']['output']>
   related_videos?: Maybe<Array<Video>>
   related_videosCount?: Maybe<Scalars['Int']['output']>
@@ -2625,6 +2626,7 @@ export type PostCreateInput = {
   photographers?: InputMaybe<ContactRelateToManyForCreateInput>
   publishedDate?: InputMaybe<Scalars['DateTime']['input']>
   publishedDateString?: InputMaybe<Scalars['String']['input']>
+  pv?: InputMaybe<Scalars['Int']['input']>
   redirect?: InputMaybe<Scalars['String']['input']>
   related_videos?: InputMaybe<VideoRelateToManyForCreateInput>
   relateds?: InputMaybe<PostRelateToManyForCreateInput>
@@ -2670,6 +2672,7 @@ export type PostOrderByInput = {
   og_title?: InputMaybe<OrderDirection>
   publishedDate?: InputMaybe<OrderDirection>
   publishedDateString?: InputMaybe<OrderDirection>
+  pv?: InputMaybe<OrderDirection>
   redirect?: InputMaybe<OrderDirection>
   state?: InputMaybe<OrderDirection>
   style?: InputMaybe<OrderDirection>
@@ -2747,6 +2750,7 @@ export type PostUpdateInput = {
   photographers?: InputMaybe<ContactRelateToManyForUpdateInput>
   publishedDate?: InputMaybe<Scalars['DateTime']['input']>
   publishedDateString?: InputMaybe<Scalars['String']['input']>
+  pv?: InputMaybe<Scalars['Int']['input']>
   redirect?: InputMaybe<Scalars['String']['input']>
   related_videos?: InputMaybe<VideoRelateToManyForUpdateInput>
   relateds?: InputMaybe<PostRelateToManyForUpdateInput>
@@ -2798,6 +2802,7 @@ export type PostWhereInput = {
   photographers?: InputMaybe<ContactManyRelationFilter>
   publishedDate?: InputMaybe<DateTimeFilter>
   publishedDateString?: InputMaybe<StringFilter>
+  pv?: InputMaybe<IntNullableFilter>
   redirect?: InputMaybe<StringFilter>
   relateds?: InputMaybe<PostManyRelationFilter>
   relatedsOne?: InputMaybe<PostWhereInput>

--- a/utils/data-schema.ts
+++ b/utils/data-schema.ts
@@ -302,7 +302,7 @@ const sportsNewsCounts = z.object({
 })
 
 export const latestSportsNewsSchema = z.object({
-  category: z
+  section: z
     .object({
       items: z.array(sportsNewsItemSchema),
       counts: sportsNewsCounts,


### PR DESCRIPTION
fix: guard Cloud Logging with ADC check and update sports news diagnostics

Prevent runtime errors in local environments by skipping Cloud Logging when ADC is not available. Also updates the latest sports news JSON source and enhances fetch diagnostics.

## Additions
- Introduced `canUseCloudLogging()` to detect Google Cloud runtime environment.
- Early return in `logPageView` and `logVideoView` if ADC is not available.
- Added JSON parsing before schema validation in `fetchLatestSportsNews`.

## Removals
- N/A

## Changes
- Changed `latestSportsNewsSchema` to use `section` instead of `category`.
- Updated the corresponding transform logic to use `rawData.section`.
- Capped latest sports news items to 4 entries.
- Updated the `URL_STATIC_LATEST_SPORTS_NEWS` to point to `section_sport_1.json`.

## Testing
- Verified logs are skipped in local dev environments without Cloud credentials.
- Confirmed latest sports news fetch works with the updated schema.
- Validated that only 4 sports news items are returned as expected.

## Screenshots
- N/A

## Todos
- Monitor in production for correct log behavior under Cloud Run.

## Task Links
[前端-改抓大分類為運動 json中的前四篇 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1212585762149020?focus=true)
