### PR TITLE
feat: show editor choice swiper arrows on desktop

### DIFF
--- a/app/_components/editor-choice/swiper-component.tsx
+++ b/app/_components/editor-choice/swiper-component.tsx
@@ -69,6 +69,7 @@ export default function SwiperComponent({ list }: Props) {
           )
         })}
         <button
+          type="button"
           className={`${homepageGtmEvents.editorChoiceButton} custom-swiper-navigation-prev`}
         >
           {/* Use sr-only to hide an element visually without hiding it from screen readers */}
@@ -80,6 +81,7 @@ export default function SwiperComponent({ list }: Props) {
           />
         </button>
         <button
+          type="button"
           className={`${homepageGtmEvents.editorChoiceButton} custom-swiper-navigation-next`}
         >
           {/* Use sr-only to hide an element visually without hiding it from screen readers */}

--- a/app/_components/editor-choice/swiper-component.tsx
+++ b/app/_components/editor-choice/swiper-component.tsx
@@ -16,7 +16,7 @@ type Props = {
 }
 
 export default function SwiperComponent({ list }: Props) {
-  const swiperNavigationButtonSize = { width: 48, height: 48 }
+  const swiperNavigationButtonSize = { width: 24, height: 24 }
 
   return (
     <div className="relative">
@@ -60,28 +60,6 @@ export default function SwiperComponent({ list }: Props) {
                     className="w-full group-hover/slide:scale-110 md:aspect-[680/379] md:group-hover/slide:scale-100 md:group-active/slide:scale-100 lg:aspect-[1127/628]"
                   />
                   <div className="absolute inset-0 md:bg-[linear-gradient(180deg,rgba(0,0,0,0.48)_6.69%,rgba(110,110,110,0.24)_17.20%,rgba(217,217,217,0.00)_20.52%,rgba(255,255,255,0)_23.25%,rgba(255,255,255,0)_74.52%,rgba(217,217,217,0.00)_74.52%,rgba(43,43,43,0.64)_83.44%,rgba(0,0,0,0.80)_96.18%)]" />
-                  <button
-                    className={`${homepageGtmEvents.editorChoiceButton} custom-swiper-navigation-prev`}
-                  >
-                    {/* Use sr-only to hide an element visually without hiding it from screen readers */}
-                    <span className="sr-only">Previous Slide</span>
-                    <Image
-                      src="icons/swiper/swiper-prev.svg"
-                      alt="slide-prev"
-                      {...swiperNavigationButtonSize}
-                    />
-                  </button>
-                  <button
-                    className={`${homepageGtmEvents.editorChoiceButton} custom-swiper-navigation-next`}
-                  >
-                    {/* Use sr-only to hide an element visually without hiding it from screen readers */}
-                    <span className="sr-only">Next Slide</span>
-                    <Image
-                      src="icons/swiper/swiper-next.svg"
-                      alt="slide-next"
-                      {...swiperNavigationButtonSize}
-                    />
-                  </button>
                 </div>
                 <p className="mt-5 line-clamp-3 h-[85px] text-xl font-bold leading-normal text-[#000928] group-hover/slide:text-[#575D71] group-active/slide:text-[#575D71] md:absolute md:bottom-3 md:left-5 md:m-0 md:line-clamp-2 md:h-auto md:max-h-[58px] md:w-[440px] md:text-white md:group-hover/slide:text-white md:group-hover/slide:underline md:group-active/slide:text-white md:group-active/slide:underline lg:bottom-7 lg:left-7 lg:max-h-[69px] lg:w-[654px] lg:text-3xl lg:font-normal">
                   {postName}
@@ -90,6 +68,28 @@ export default function SwiperComponent({ list }: Props) {
             </SwiperSlide>
           )
         })}
+        <button
+          className={`${homepageGtmEvents.editorChoiceButton} custom-swiper-navigation-prev`}
+        >
+          {/* Use sr-only to hide an element visually without hiding it from screen readers */}
+          <span className="sr-only">Previous Slide</span>
+          <Image
+            src="/icons/swiper/swiper-prev.svg"
+            alt="slide-prev"
+            {...swiperNavigationButtonSize}
+          />
+        </button>
+        <button
+          className={`${homepageGtmEvents.editorChoiceButton} custom-swiper-navigation-next`}
+        >
+          {/* Use sr-only to hide an element visually without hiding it from screen readers */}
+          <span className="sr-only">Next Slide</span>
+          <Image
+            src="/icons/swiper/swiper-next.svg"
+            alt="slide-next"
+            {...swiperNavigationButtonSize}
+          />
+        </button>
         <div className="custom-swiper-pagination" />
       </Swiper>
     </div>

--- a/shared-styles/global.css
+++ b/shared-styles/global.css
@@ -46,7 +46,7 @@
   }
 
   .promote-topic-swiper-bullet {
-    @apply inline-block size-1 lg:size-[6px] cursor-pointer rounded-full bg-mirror-blue-600;
+    @apply inline-block size-1 cursor-pointer rounded-full bg-mirror-blue-600 lg:size-[6px];
   }
 
   .promote-topic-swiper-bullet-active {
@@ -54,22 +54,25 @@
   }
 
   .promote-topic-swiper-pagination-horizontal {
-    @apply flex w-full items-center justify-center gap-[10px] z-10 absolute !bottom-[5px];
+    @apply absolute !bottom-[5px] z-10 flex w-full items-center justify-center gap-[10px];
   }
 
   /* editor choice swiper button */
   .swiper {
     .custom-swiper-navigation-next,
     .custom-swiper-navigation-prev {
-      @apply absolute top-1/2 z-20 size-6 md:hidden -translate-y-1/2 items-center justify-center;
+      @apply absolute top-[calc((100%_-_105px)_/_2)] z-20 size-6 -translate-y-1/2 items-center justify-center md:top-1/2 lg:size-14;
+      > img {
+        margin: 0 auto;
+      }
     }
 
     .custom-swiper-navigation-next {
-      @apply right-2;
+      @apply right-2 lg:right-0;
     }
 
     .custom-swiper-navigation-prev {
-      @apply left-2;
+      @apply left-2 lg:left-0;
     }
   }
   .header-submit-button {

--- a/shared-styles/global.css
+++ b/shared-styles/global.css
@@ -61,10 +61,7 @@
   .swiper {
     .custom-swiper-navigation-next,
     .custom-swiper-navigation-prev {
-      @apply absolute top-[calc((100%_-_105px)_/_2)] z-20 size-6 -translate-y-1/2 items-center justify-center md:top-1/2 lg:size-14;
-      > img {
-        margin: 0 auto;
-      }
+      @apply absolute top-[calc((100%_-_105px)_/_2)] z-20 flex size-6 -translate-y-1/2 items-center justify-center md:top-1/2 lg:size-14;
     }
 
     .custom-swiper-navigation-next {

--- a/shared-styles/global.css
+++ b/shared-styles/global.css
@@ -61,7 +61,7 @@
   .swiper {
     .custom-swiper-navigation-next,
     .custom-swiper-navigation-prev {
-      @apply absolute top-[calc((100%_-_105px)_/_2)] z-20 flex size-6 -translate-y-1/2 items-center justify-center md:top-1/2 lg:size-14;
+      @apply absolute top-[calc((100%_-_105px)_/_2)] z-20 flex size-6 -translate-y-1/2 items-center justify-center md:top-1/2 md:hidden lg:flex lg:size-14;
     }
 
     .custom-swiper-navigation-next {


### PR DESCRIPTION
This PR mainly fixes the issue where swiper arrows are missing on PC.
Additionally, during implementation, I noticed that the current arrows were being rendered once per image, so I refactored it to render only a single set of arrows on whole `SwiperComponent`.
This improves rendering performance.

## Additions
- N/A

## Removals
- N/A

## Changes
- Show arrows and enlarge click region to improve user experience on PC
- Move prev/next buttons out of each `SwiperSlide` 
- Set default arrow size to 24px
- Fix arrow button image src to absolute public path

## Testing
- N/A

## Screenshots
- N/A

## Todos
- N/A

## Task Links
- [[鏡報]首頁PC版編輯精選增加輪播左右箭頭](https://app.asana.com/1/614399484723017/project/1215270345706753/task/1215183093097083?focus=true)