### PR TITLE
feat(topic): add firstThreePostTitles as new fallback value for description related meta tags

### DIFF
--- a/app/topic/[slug]/_components/group-type/index.tsx
+++ b/app/topic/[slug]/_components/group-type/index.tsx
@@ -1,6 +1,6 @@
 import type { GetTopicBasicInfoQuery } from '@/graphql/__generated__/graphql'
 import { notFound } from 'next/navigation'
-import { fetchGorupTypeTopicPostBySlug } from '../../../action'
+import { fetchGroupTypeTopicPostBySlug } from '../../../action'
 import List from './list'
 import { SITE_URL } from '@/constants/config'
 import { IMAGE_PATH } from '@/constants/default-path'
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export default async function GroupTypeListing({ slug, tags }: Props) {
-  const posts = await fetchGorupTypeTopicPostBySlug(slug)
+  const posts = await fetchGroupTypeTopicPostBySlug(slug)
 
   if (posts.length === 0) notFound()
 

--- a/app/topic/[slug]/_components/group-type/index.tsx
+++ b/app/topic/[slug]/_components/group-type/index.tsx
@@ -4,6 +4,7 @@ import { fetchGroupTypeTopicPostBySlug } from '../../../action'
 import List from './list'
 import { SITE_URL } from '@/constants/config'
 import { IMAGE_PATH } from '@/constants/default-path'
+import { filterPostsByTag } from '@/utils/topic'
 
 type Tag = NonNullable<NonNullable<GetTopicBasicInfoQuery['topic']>['tags']>[0]
 
@@ -45,9 +46,7 @@ export default async function GroupTypeListing({ slug, tags }: Props) {
     <List
       key={tag.id}
       groupName={tag.name || ''}
-      posts={posts.filter((post) =>
-        post.tags.some((postTag) => postTag.id === tag.id)
-      )}
+      posts={filterPostsByTag(posts, tag)}
     />
   ))
 

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -49,37 +49,36 @@ export async function generateMetadata({
   const mainImage = selectMainImage(heroImage, ogImage)
   const image = mainImage.resized?.original || IMAGE_PATH
 
-  let posts: { title: string }[] = []
+  let description =
+    topic.og_description || getFirstParagraphFromApiData(topic.apiDataBrief)
 
-  switch (topic.type) {
-    case TOPIC_LIST_TYPE.GROUP: {
-      const allPosts = await fetchGroupTypeTopicPostBySlug(slug)
-      posts = (topic.tags || [])
-        .flatMap((tag) =>
-          allPosts.filter((post) =>
-            post.tags.some((postTag) => postTag.id === tag.id)
+  if (!description) {
+    let posts: { title: string }[] = []
+
+    switch (topic.type) {
+      case TOPIC_LIST_TYPE.GROUP: {
+        const allPosts = await fetchGroupTypeTopicPostBySlug(slug)
+        posts = (topic.tags || [])
+          .flatMap((tag) =>
+            allPosts.filter((post) =>
+              post.tags.some((postTag) => postTag.id === tag.id)
+            )
           )
-        )
-        .slice(0, 3)
-      break
+          .slice(0, 3)
+        break
+      }
+      case TOPIC_LIST_TYPE.LIST: {
+        const { postsData } = await fetchListTypeTopicPostBySlug({
+          slug,
+          take: 3,
+        })
+        posts = postsData
+        break
+      }
     }
-    case TOPIC_LIST_TYPE.LIST: {
-      const { postsData } = await fetchListTypeTopicPostBySlug({
-        slug,
-        take: 3,
-      })
-      posts = postsData
-      break
-    }
+
+    description = posts.map((post) => post.title).join('、') || ''
   }
-
-  const firstThreePostTitles = posts.map((post) => post.title).join('、')
-
-  const description =
-    topic.og_description ||
-    getFirstParagraphFromApiData(topic.apiDataBrief) ||
-    firstThreePostTitles ||
-    ''
 
   const metaData = Object.assign(
     {},

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -73,10 +73,7 @@ export async function generateMetadata({
     }
   }
 
-  const firstThreePostTitles = posts
-    .slice(0, 3)
-    .map((post) => post.title)
-    .join('、')
+  const firstThreePostTitles = posts.map((post) => post.title).join('、')
 
   const description =
     topic.og_description ||

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -67,7 +67,8 @@ export async function generateMetadata({
           .slice(0, 3)
         break
       }
-      case TOPIC_LIST_TYPE.LIST: {
+      case TOPIC_LIST_TYPE.LIST:
+      default: {
         const { postsData } = await fetchListTypeTopicPostBySlug({
           slug,
           take: 3,

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -53,7 +53,7 @@ export async function generateMetadata({
 
   switch (topic.type) {
     case TOPIC_LIST_TYPE.GROUP:
-      posts = await fetchGroupTypeTopicPostBySlug(slug)
+      posts = await fetchGroupTypeTopicPostBySlug(slug, 3)
       break
     case TOPIC_LIST_TYPE.LIST: {
       const { postsData } = await fetchListTypeTopicPostBySlug({

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -76,10 +76,6 @@ export async function generateMetadata({
     firstThreePostTitles ||
     ''
 
-  const other = {
-    'article-description': description,
-  }
-
   const metaData = Object.assign(
     {},
     {
@@ -93,7 +89,6 @@ export async function generateMetadata({
         url: getTopicPageUrl(slug),
         images: image,
       },
-      other,
     }
   )
 

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -76,6 +76,10 @@ export async function generateMetadata({
     firstThreePostTitles ||
     ''
 
+  const other = {
+    'article-description': description,
+  }
+
   const metaData = Object.assign(
     {},
     {
@@ -89,6 +93,7 @@ export async function generateMetadata({
         url: getTopicPageUrl(slug),
         images: image,
       },
+      other,
     }
   )
 

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -26,6 +26,7 @@ import {
   fetchGroupTypeTopicPostBySlug,
   fetchListTypeTopicPostBySlug,
 } from '../action'
+import { filterPostsByTag } from '@/utils/topic'
 
 type PageProps = {
   params: { slug: string }
@@ -59,11 +60,7 @@ export async function generateMetadata({
       case TOPIC_LIST_TYPE.GROUP: {
         const allPosts = await fetchGroupTypeTopicPostBySlug(slug)
         posts = (topic.tags || [])
-          .flatMap((tag) =>
-            allPosts.filter((post) =>
-              post.tags.some((postTag) => postTag.id === tag.id)
-            )
-          )
+          .flatMap((tag) => filterPostsByTag(allPosts, tag))
           .slice(0, 3)
         break
       }

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -52,9 +52,17 @@ export async function generateMetadata({
   let posts: { title: string }[] = []
 
   switch (topic.type) {
-    case TOPIC_LIST_TYPE.GROUP:
-      posts = await fetchGroupTypeTopicPostBySlug(slug, 3)
+    case TOPIC_LIST_TYPE.GROUP: {
+      const allPosts = await fetchGroupTypeTopicPostBySlug(slug)
+      posts = (topic.tags || [])
+        .flatMap((tag) =>
+          allPosts.filter((post) =>
+            post.tags.some((postTag) => postTag.id === tag.id)
+          )
+        )
+        .slice(0, 3)
       break
+    }
     case TOPIC_LIST_TYPE.LIST: {
       const { postsData } = await fetchListTypeTopicPostBySlug({
         slug,

--- a/app/topic/[slug]/page.tsx
+++ b/app/topic/[slug]/page.tsx
@@ -22,6 +22,10 @@ import ListTypeListing from './_components/list-type'
 import GroupTypeListing from './_components/group-type'
 import { getTopicPageUrl } from '@/utils/site-urls'
 import { getDefaultMetadata } from '@/utils/common'
+import {
+  fetchGroupTypeTopicPostBySlug,
+  fetchListTypeTopicPostBySlug,
+} from '../action'
 
 type PageProps = {
   params: { slug: string }
@@ -40,14 +44,37 @@ export async function generateMetadata({
   const defaultMetadata = getDefaultMetadata()
 
   const title = `${topic.og_title || topic.name} - ${SITE_NAME}`
-  const description =
-    topic.og_description ||
-    getFirstParagraphFromApiData(topic.apiDataBrief) ||
-    ''
   const heroImage = getHeroImage(topic.heroImage)
   const ogImage = getHeroImage(topic.og_image)
   const mainImage = selectMainImage(heroImage, ogImage)
   const image = mainImage.resized?.original || IMAGE_PATH
+
+  let posts: { title: string }[] = []
+
+  switch (topic.type) {
+    case TOPIC_LIST_TYPE.GROUP:
+      posts = await fetchGroupTypeTopicPostBySlug(slug)
+      break
+    case TOPIC_LIST_TYPE.LIST: {
+      const { postsData } = await fetchListTypeTopicPostBySlug({
+        slug,
+        take: 3,
+      })
+      posts = postsData
+      break
+    }
+  }
+
+  const firstThreePostTitles = posts
+    .slice(0, 3)
+    .map((post) => post.title)
+    .join('、')
+
+  const description =
+    topic.og_description ||
+    getFirstParagraphFromApiData(topic.apiDataBrief) ||
+    firstThreePostTitles ||
+    ''
 
   const metaData = Object.assign(
     {},

--- a/app/topic/action.ts
+++ b/app/topic/action.ts
@@ -91,7 +91,9 @@ async function fetchListTypeTopicPostBySlug({
 
       const result = schema.parse(rawData?.topic)
 
-      const postsData = result.items.map(transformRawPost)
+      const postsData = take
+        ? result.items.map(transformRawPost).slice(0, take)
+        : result.items.map(transformRawPost)
       const postsCount = result.counts.posts + result.counts.externals
 
       return {

--- a/app/topic/action.ts
+++ b/app/topic/action.ts
@@ -191,8 +191,7 @@ const transformRawPostWithTags = (
 }
 
 async function fetchGroupTypeTopicPostBySlug(
-  slug: string,
-  take?: number
+  slug: string
 ): Promise<PostDataWithTags[]> {
   const errorLogger = createErrorLogger(
     `Error occurs while fetching group type topic posts (slug: ${slug})`,
@@ -245,7 +244,6 @@ async function fetchGroupTypeTopicPostBySlug(
         GetGroupTypeTopicPostsDocument,
         {
           slug,
-          take,
         }
       )
       if (rawData && rawData.topic && Array.isArray(rawData.topic.posts)) {

--- a/app/topic/action.ts
+++ b/app/topic/action.ts
@@ -189,7 +189,8 @@ const transformRawPostWithTags = (
 }
 
 async function fetchGroupTypeTopicPostBySlug(
-  slug: string
+  slug: string,
+  take?: number
 ): Promise<PostDataWithTags[]> {
   const errorLogger = createErrorLogger(
     `Error occurs while fetching group type topic posts (slug: ${slug})`,
@@ -242,6 +243,7 @@ async function fetchGroupTypeTopicPostBySlug(
         GetGroupTypeTopicPostsDocument,
         {
           slug,
+          take,
         }
       )
       if (rawData && rawData.topic && Array.isArray(rawData.topic.posts)) {

--- a/app/topic/action.ts
+++ b/app/topic/action.ts
@@ -188,7 +188,7 @@ const transformRawPostWithTags = (
   }
 }
 
-async function fetchGorupTypeTopicPostBySlug(
+async function fetchGroupTypeTopicPostBySlug(
   slug: string
 ): Promise<PostDataWithTags[]> {
   const errorLogger = createErrorLogger(
@@ -319,6 +319,6 @@ async function fetchTopicListingByPage({
 export {
   fetchTopicBasicInfo,
   fetchListTypeTopicPostBySlug,
-  fetchGorupTypeTopicPostBySlug,
+  fetchGroupTypeTopicPostBySlug,
   fetchTopicListingByPage,
 }

--- a/graphql/__generated__/graphql.ts
+++ b/graphql/__generated__/graphql.ts
@@ -1425,6 +1425,8 @@ export type Mutation = {
   createPopularTags?: Maybe<Array<Maybe<PopularTag>>>
   createPost?: Maybe<Post>
   createPosts?: Maybe<Array<Maybe<Post>>>
+  createPromoteTopic?: Maybe<PromoteTopic>
+  createPromoteTopics?: Maybe<Array<Maybe<PromoteTopic>>>
   createSection?: Maybe<Section>
   createSections?: Maybe<Array<Maybe<Section>>>
   createTag?: Maybe<Tag>
@@ -1465,6 +1467,8 @@ export type Mutation = {
   deletePopularTags?: Maybe<Array<Maybe<PopularTag>>>
   deletePost?: Maybe<Post>
   deletePosts?: Maybe<Array<Maybe<Post>>>
+  deletePromoteTopic?: Maybe<PromoteTopic>
+  deletePromoteTopics?: Maybe<Array<Maybe<PromoteTopic>>>
   deleteSection?: Maybe<Section>
   deleteSections?: Maybe<Array<Maybe<Section>>>
   deleteTag?: Maybe<Tag>
@@ -1506,6 +1510,8 @@ export type Mutation = {
   updatePopularTags?: Maybe<Array<Maybe<PopularTag>>>
   updatePost?: Maybe<Post>
   updatePosts?: Maybe<Array<Maybe<Post>>>
+  updatePromoteTopic?: Maybe<PromoteTopic>
+  updatePromoteTopics?: Maybe<Array<Maybe<PromoteTopic>>>
   updateSection?: Maybe<Section>
   updateSections?: Maybe<Array<Maybe<Section>>>
   updateTag?: Maybe<Tag>
@@ -1639,6 +1645,14 @@ export type MutationCreatePostArgs = {
 
 export type MutationCreatePostsArgs = {
   data: Array<PostCreateInput>
+}
+
+export type MutationCreatePromoteTopicArgs = {
+  data: PromoteTopicCreateInput
+}
+
+export type MutationCreatePromoteTopicsArgs = {
+  data: Array<PromoteTopicCreateInput>
 }
 
 export type MutationCreateSectionArgs = {
@@ -1799,6 +1813,14 @@ export type MutationDeletePostArgs = {
 
 export type MutationDeletePostsArgs = {
   where: Array<PostWhereUniqueInput>
+}
+
+export type MutationDeletePromoteTopicArgs = {
+  where: PromoteTopicWhereUniqueInput
+}
+
+export type MutationDeletePromoteTopicsArgs = {
+  where: Array<PromoteTopicWhereUniqueInput>
 }
 
 export type MutationDeleteSectionArgs = {
@@ -1973,6 +1995,15 @@ export type MutationUpdatePostArgs = {
 
 export type MutationUpdatePostsArgs = {
   data: Array<PostUpdateArgs>
+}
+
+export type MutationUpdatePromoteTopicArgs = {
+  data: PromoteTopicUpdateInput
+  where: PromoteTopicWhereUniqueInput
+}
+
+export type MutationUpdatePromoteTopicsArgs = {
+  data: Array<PromoteTopicUpdateArgs>
 }
 
 export type MutationUpdateSectionArgs = {
@@ -2826,6 +2857,70 @@ export type PostWhereUniqueInput = {
   id?: InputMaybe<Scalars['ID']['input']>
 }
 
+export type PromoteTopic = {
+  __typename?: 'PromoteTopic'
+  createdAt?: Maybe<Scalars['DateTime']['output']>
+  createdBy?: Maybe<User>
+  id: Scalars['ID']['output']
+  order?: Maybe<Scalars['Int']['output']>
+  state?: Maybe<Scalars['String']['output']>
+  topics?: Maybe<Topic>
+  updatedAt?: Maybe<Scalars['DateTime']['output']>
+  updatedBy?: Maybe<User>
+}
+
+export type PromoteTopicCreateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>
+  createdBy?: InputMaybe<UserRelateToOneForCreateInput>
+  order?: InputMaybe<Scalars['Int']['input']>
+  state?: InputMaybe<Scalars['String']['input']>
+  topics?: InputMaybe<TopicRelateToOneForCreateInput>
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>
+  updatedBy?: InputMaybe<UserRelateToOneForCreateInput>
+}
+
+export type PromoteTopicOrderByInput = {
+  createdAt?: InputMaybe<OrderDirection>
+  id?: InputMaybe<OrderDirection>
+  order?: InputMaybe<OrderDirection>
+  state?: InputMaybe<OrderDirection>
+  updatedAt?: InputMaybe<OrderDirection>
+}
+
+export type PromoteTopicUpdateArgs = {
+  data: PromoteTopicUpdateInput
+  where: PromoteTopicWhereUniqueInput
+}
+
+export type PromoteTopicUpdateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>
+  createdBy?: InputMaybe<UserRelateToOneForUpdateInput>
+  order?: InputMaybe<Scalars['Int']['input']>
+  state?: InputMaybe<Scalars['String']['input']>
+  topics?: InputMaybe<TopicRelateToOneForUpdateInput>
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>
+  updatedBy?: InputMaybe<UserRelateToOneForUpdateInput>
+}
+
+export type PromoteTopicWhereInput = {
+  AND?: InputMaybe<Array<PromoteTopicWhereInput>>
+  NOT?: InputMaybe<Array<PromoteTopicWhereInput>>
+  OR?: InputMaybe<Array<PromoteTopicWhereInput>>
+  createdAt?: InputMaybe<DateTimeNullableFilter>
+  createdBy?: InputMaybe<UserWhereInput>
+  id?: InputMaybe<IdFilter>
+  order?: InputMaybe<IntNullableFilter>
+  state?: InputMaybe<StringNullableFilter>
+  topics?: InputMaybe<TopicWhereInput>
+  updatedAt?: InputMaybe<DateTimeNullableFilter>
+  updatedBy?: InputMaybe<UserWhereInput>
+}
+
+export type PromoteTopicWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>
+  order?: InputMaybe<Scalars['Int']['input']>
+}
+
 export type Query = {
   __typename?: 'Query'
   audioFile?: Maybe<AudioFile>
@@ -2872,6 +2967,9 @@ export type Query = {
   post?: Maybe<Post>
   posts?: Maybe<Array<Post>>
   postsCount?: Maybe<Scalars['Int']['output']>
+  promoteTopic?: Maybe<PromoteTopic>
+  promoteTopics?: Maybe<Array<PromoteTopic>>
+  promoteTopicsCount?: Maybe<Scalars['Int']['output']>
   section?: Maybe<Section>
   sections?: Maybe<Array<Section>>
   sectionsCount?: Maybe<Scalars['Int']['output']>
@@ -2881,6 +2979,7 @@ export type Query = {
   topic?: Maybe<Topic>
   topics?: Maybe<Array<Topic>>
   topicsCount?: Maybe<Scalars['Int']['output']>
+  trafficDashboardEnabled: Scalars['Boolean']['output']
   user?: Maybe<User>
   users?: Maybe<Array<User>>
   usersCount?: Maybe<Scalars['Int']['output']>
@@ -3114,6 +3213,22 @@ export type QueryPostsArgs = {
 
 export type QueryPostsCountArgs = {
   where?: PostWhereInput
+}
+
+export type QueryPromoteTopicArgs = {
+  where: PromoteTopicWhereUniqueInput
+}
+
+export type QueryPromoteTopicsArgs = {
+  cursor?: InputMaybe<PromoteTopicWhereUniqueInput>
+  orderBy?: Array<PromoteTopicOrderByInput>
+  skip?: Scalars['Int']['input']
+  take?: InputMaybe<Scalars['Int']['input']>
+  where?: PromoteTopicWhereInput
+}
+
+export type QueryPromoteTopicsCountArgs = {
+  where?: PromoteTopicWhereInput
 }
 
 export type QuerySectionArgs = {

--- a/utils/data-schema.ts
+++ b/utils/data-schema.ts
@@ -340,19 +340,23 @@ export const countsSchema = z.object({
 })
 
 const topicStorySchema = sectionStorySchema.extend({
-  tags: z.array(
-    z.object({
-      id: z.string(),
-    })
-  ),
+  tags: z
+    .array(
+      z.object({
+        id: z.string(),
+      })
+    )
+    .optional(),
 })
 
 const topicExternalSchema = sectionExternalSchema.extend({
-  tags: z.array(
-    z.object({
-      id: z.string(),
-    })
-  ),
+  tags: z
+    .array(
+      z.object({
+        id: z.string(),
+      })
+    )
+    .optional(),
 })
 
 export const topicPostSchema = z.union([topicStorySchema, topicExternalSchema])

--- a/utils/data-schema.ts
+++ b/utils/data-schema.ts
@@ -340,23 +340,19 @@ export const countsSchema = z.object({
 })
 
 const topicStorySchema = sectionStorySchema.extend({
-  tags: z
-    .array(
-      z.object({
-        id: z.string(),
-      })
-    )
-    .optional(),
+  tags: z.array(
+    z.object({
+      id: z.string(),
+    })
+  ),
 })
 
 const topicExternalSchema = sectionExternalSchema.extend({
-  tags: z
-    .array(
-      z.object({
-        id: z.string(),
-      })
-    )
-    .optional(),
+  tags: z.array(
+    z.object({
+      id: z.string(),
+    })
+  ),
 })
 
 export const topicPostSchema = z.union([topicStorySchema, topicExternalSchema])

--- a/utils/topic.ts
+++ b/utils/topic.ts
@@ -1,3 +1,5 @@
+import type { PostDataWithTags } from '@/types/topic'
+
 export function getUrlFromTopicKeywords(keyword?: string | null) {
   if (!keyword) return undefined
 
@@ -6,4 +8,13 @@ export function getUrlFromTopicKeywords(keyword?: string | null) {
   }
 
   return undefined
+}
+
+export function filterPostsByTag(
+  posts: PostDataWithTags[],
+  tag: { id: string }
+) {
+  return posts.filter((post) =>
+    post.tags.some((postTag) => postTag.id === tag.id)
+  )
 }


### PR DESCRIPTION
# 描述

- 新增變數 `firstThreePostTitles` 作為既有 meta tags: `description`、`og:description` 和 `twitter:description` 的新 fallback value，當 CMS 前言相關欄位無內容時，改抓該 `/topic/[slug]` 的前三篇文章標題
- 新增 `article-description` meta tag，顯示邏輯與內容和上述相同
- 修正這次有用到、定義在 `app/topic/action.ts` 的函式名稱 typo 

**參考資源**

- 任務卡
https://app.asana.com/1/614399484723017/project/1214559748867622/task/1214468356520546