### PR TITLE
feat: output published/modified time in meta tags and JSON-LD with Taipei ISO offset

### DIFF
--- a/app/external/[id]/page.tsx
+++ b/app/external/[id]/page.tsx
@@ -37,6 +37,16 @@ export async function generateMetadata({
   const title = `${externalPost.title} - ${SITE_NAME}`
   const description = externalPost.brief
   const image = externalPost.thumb || IMAGE_PATH
+  const publishedTime = externalPost.publishedTimeIso
+  const updatedTime = externalPost.updatedTimeIso
+  const other: Record<string, string> = {
+    pubdate: publishedTime,
+    'article:published_time': publishedTime,
+    ...(updatedTime && {
+      lastmod: updatedTime,
+      'article:modified_time': updatedTime,
+    }),
+  }
 
   const metaData = Object.assign(
     {},
@@ -52,6 +62,7 @@ export async function generateMetadata({
         images: image,
         type: 'website',
       },
+      other,
     }
   )
 
@@ -86,7 +97,8 @@ export default async function Page({ params }: PageProps) {
     title,
     partner,
     thumb,
-    publishedTime,
+    publishedTimeIso,
+    updatedTimeIso,
     brief,
     content,
     link,
@@ -101,7 +113,8 @@ export default async function Page({ params }: PageProps) {
       headline: title,
       author: partner ? { name: partner } : { name: SITE_NAME },
       image: thumb || `${SITE_URL}${IMAGE_PATH}`,
-      datePublished: new Date(publishedTime).toISOString(),
+      datePublished: publishedTimeIso,
+      ...(updatedTimeIso && { dateModified: updatedTimeIso }),
     },
     ...sections.map((section) => ({
       '@context': 'https://schema.org',

--- a/app/external/[id]/page.tsx
+++ b/app/external/[id]/page.tsx
@@ -40,8 +40,10 @@ export async function generateMetadata({
   const publishedTime = externalPost.publishedTimeIso
   const updatedTime = externalPost.updatedTimeIso
   const other: Record<string, string> = {
-    pubdate: publishedTime,
-    'article:published_time': publishedTime,
+    ...(publishedTime && {
+      pubdate: publishedTime,
+      'article:published_time': publishedTime,
+    }),
     ...(updatedTime && {
       lastmod: updatedTime,
       'article:modified_time': updatedTime,
@@ -113,7 +115,7 @@ export default async function Page({ params }: PageProps) {
       headline: title,
       author: partner ? { name: partner } : { name: SITE_NAME },
       image: thumb || `${SITE_URL}${IMAGE_PATH}`,
-      datePublished: publishedTimeIso,
+      ...(publishedTimeIso && { datePublished: publishedTimeIso }),
       ...(updatedTimeIso && { dateModified: updatedTimeIso }),
     },
     ...sections.map((section) => ({

--- a/app/external/action.ts
+++ b/app/external/action.ts
@@ -26,9 +26,13 @@ function transformExternal(
   const partner = rawData.partner?.name ?? ''
   const partnerSlug = rawData.partner?.slug ?? ''
   const externalsLink = getExternalsPageUrl(partnerSlug)
-  const publishedTime = dateFormatter(rawData.publishedDate) ?? ''
+  const publishedTime = rawData.publishedDate
+    ? dateFormatter(rawData.publishedDate)
+    : ''
   const updatedTime = rawData.updatedAt ? dateFormatter(rawData.updatedAt) : ''
-  const publishedTimeIso = toIsoStringWithTaipeiOffset(rawData.publishedDate)
+  const publishedTimeIso = rawData.publishedDate
+    ? toIsoStringWithTaipeiOffset(rawData.publishedDate)
+    : ''
   const updatedTimeIso = rawData.updatedAt
     ? toIsoStringWithTaipeiOffset(rawData.updatedAt)
     : ''

--- a/app/external/action.ts
+++ b/app/external/action.ts
@@ -8,7 +8,11 @@ import {
 } from '@/graphql/__generated__/graphql'
 import type { GetExternalByIdQuery } from '@/graphql/__generated__/graphql'
 import type { ExternalPost } from '@/types/external'
-import { dateFormatter, transformRawRelatedPosts } from '@/utils/data-process'
+import {
+  dateFormatter,
+  toIsoStringWithTaipeiOffset,
+  transformRawRelatedPosts,
+} from '@/utils/data-process'
 import { getExternalPageUrl, getExternalsPageUrl } from '@/utils/site-urls'
 import type { RelatedPost } from '@/types/common'
 
@@ -24,6 +28,10 @@ function transformExternal(
   const externalsLink = getExternalsPageUrl(partnerSlug)
   const publishedTime = dateFormatter(rawData.publishedDate) ?? ''
   const updatedTime = rawData.updatedAt ? dateFormatter(rawData.updatedAt) : ''
+  const publishedTimeIso = toIsoStringWithTaipeiOffset(rawData.publishedDate)
+  const updatedTimeIso = rawData.updatedAt
+    ? toIsoStringWithTaipeiOffset(rawData.updatedAt)
+    : ''
   const brief = rawData.brief ?? ''
   const content = rawData.content ?? ''
   const tags =
@@ -56,6 +64,8 @@ function transformExternal(
     externalsLink,
     publishedTime,
     updatedTime,
+    publishedTimeIso,
+    updatedTimeIso,
     brief,
     content,
     tags,

--- a/app/external/action.ts
+++ b/app/external/action.ts
@@ -8,11 +8,11 @@ import {
 } from '@/graphql/__generated__/graphql'
 import type { GetExternalByIdQuery } from '@/graphql/__generated__/graphql'
 import type { ExternalPost } from '@/types/external'
+import { transformRawRelatedPosts } from '@/utils/data-process'
 import {
-  dateFormatter,
+  toDisplayDateTimeInTaipei,
   toIsoStringWithTaipeiOffset,
-  transformRawRelatedPosts,
-} from '@/utils/data-process'
+} from '@/utils/date'
 import { getExternalPageUrl, getExternalsPageUrl } from '@/utils/site-urls'
 import type { RelatedPost } from '@/types/common'
 
@@ -27,9 +27,11 @@ function transformExternal(
   const partnerSlug = rawData.partner?.slug ?? ''
   const externalsLink = getExternalsPageUrl(partnerSlug)
   const publishedTime = rawData.publishedDate
-    ? dateFormatter(rawData.publishedDate)
+    ? toDisplayDateTimeInTaipei(rawData.publishedDate)
     : ''
-  const updatedTime = rawData.updatedAt ? dateFormatter(rawData.updatedAt) : ''
+  const updatedTime = rawData.updatedAt
+    ? toDisplayDateTimeInTaipei(rawData.updatedAt)
+    : ''
   const publishedTimeIso = rawData.publishedDate
     ? toIsoStringWithTaipeiOffset(rawData.publishedDate)
     : ''

--- a/app/externals/actions.ts
+++ b/app/externals/actions.ts
@@ -12,7 +12,7 @@ import type {
 import { getExternalPageUrl } from '@/utils/site-urls'
 import { DEFAULT_SECTION_NAME, DEFAULT_SECTION_COLOR } from '@/constants/misc'
 import type { External } from '@/types/externals'
-import { dateFormatter } from '@/utils/data-process'
+import { toDisplayDateTimeInTaipei } from '@/utils/date'
 
 function transformPartnerInformation(
   rawData: GetPartnerInformationQuery['partner']
@@ -55,7 +55,9 @@ function transformExternal(
     const link = getExternalPageUrl(rawExternal.id)
     const title = rawExternal.title ?? ''
     const thumb = rawExternal.thumb ?? ''
-    const publishedDate = dateFormatter(rawExternal.publishedDate ?? '')
+    const publishedDate = toDisplayDateTimeInTaipei(
+      rawExternal.publishedDate ?? ''
+    )
     const textContent = rawExternal.brief ?? ''
     const sectionName = DEFAULT_SECTION_NAME
     const sectionColor = DEFAULT_SECTION_COLOR

--- a/app/search/_components/miso-search.tsx
+++ b/app/search/_components/miso-search.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useMemo } from 'react'
-import { dateFormatter } from '@/utils/data-process'
+import { toDisplayDateTimeInTaipei } from '@/utils/date'
 import { MISO_API_KEY } from '@/constants/config'
 import '@/shared-styles/search.css'
 import { searchGtmEvents } from '@/constants/gtm'
@@ -90,7 +90,9 @@ export default function MisoSearch() {
             <div class="miso-list__item-info-container">
               <div class='miso-list__item-time'>${
                 product['published_at']?.toString()
-                  ? dateFormatter(product['published_at']?.toString())
+                  ? toDisplayDateTimeInTaipei(
+                      product['published_at']?.toString()
+                    )
                   : ''
               }</div>
               <div class="miso-list__item-title">${product.title}</div>

--- a/app/search/_components/search-results-list.tsx
+++ b/app/search/_components/search-results-list.tsx
@@ -1,6 +1,6 @@
 'use client'
 import InfiniteScrollList from '@readr-media/react-infinite-scroll-list'
-import { dateFormatter } from '@/utils/data-process'
+import { toDisplayDateTimeInTaipei } from '@/utils/date'
 import { searchGtmEvents } from '@/constants/gtm'
 import { IMAGE_PATH } from '@/constants/default-path'
 
@@ -64,7 +64,7 @@ export default function SearchResultsList({
                 <div className="p-2.5">
                   <div className="mt-2 font-['Noto_Sans_CJK_TC'] text-sm font-normal leading-normal tracking-[0.5px] text-[#2B2B2B] [font-feature-settings:'liga'_off,'clig'_off]">
                     {product.published_at
-                      ? dateFormatter(product.published_at)
+                      ? toDisplayDateTimeInTaipei(product.published_at)
                       : ''}
                   </div>
                   <div className="mt-3 line-clamp-2 text-justify font-['Noto_Sans_CJK_TC'] text-lg font-bold leading-normal text-[#4A4A4A] [font-feature-settings:'liga'_off,'clig'_off]">

--- a/app/story/[id]/page.tsx
+++ b/app/story/[id]/page.tsx
@@ -54,8 +54,10 @@ export async function generateMetadata({
   const publishedTime = postData.publishedTimeIso
   const updatedTime = postData.updatedTimeIso
   const other: Record<string, string> = {
-    pubdate: publishedTime,
-    'article:published_time': publishedTime,
+    ...(publishedTime && {
+      pubdate: publishedTime,
+      'article:published_time': publishedTime,
+    }),
     ...(updatedTime && {
       lastmod: updatedTime,
       'article:modified_time': updatedTime,
@@ -140,7 +142,9 @@ export default async function Page({ params }: PageProps) {
       author: author,
       image:
         postData.postMainImage?.resized?.original || `${SITE_URL}${IMAGE_PATH}`,
-      datePublished: postData.publishedTimeIso,
+      ...(postData.publishedTimeIso && {
+        datePublished: postData.publishedTimeIso,
+      }),
       ...(postData.updatedTimeIso && {
         dateModified: postData.updatedTimeIso,
       }),

--- a/app/story/[id]/page.tsx
+++ b/app/story/[id]/page.tsx
@@ -51,8 +51,15 @@ export async function generateMetadata({
     .filter(Boolean)
     .join(', ')
   const keywords = [...tags, ...algoTags].filter(Boolean).join(', ')
+  const publishedTime = postData.publishedTimeIso
+  const updatedTime = postData.updatedTimeIso
   const other: Record<string, string> = {
-    'article:published_time': new Date(postData.publishedTime).toISOString(),
+    pubdate: publishedTime,
+    'article:published_time': publishedTime,
+    ...(updatedTime && {
+      lastmod: updatedTime,
+      'article:modified_time': updatedTime,
+    }),
     'article:section': postData.sections?.[0]?.name || 'UnCategorized',
     'dable:author': postData.writers?.[0]
       ? postData.writers[0].name
@@ -133,7 +140,10 @@ export default async function Page({ params }: PageProps) {
       author: author,
       image:
         postData.postMainImage?.resized?.original || `${SITE_URL}${IMAGE_PATH}`,
-      datePublished: new Date(postData.publishedTime).toISOString(),
+      datePublished: postData.publishedTimeIso,
+      ...(postData.updatedTimeIso && {
+        dateModified: postData.updatedTimeIso,
+      }),
     },
     ...postData.sections.map((section) => ({
       '@context': 'https://schema.org',

--- a/app/story/actions.ts
+++ b/app/story/actions.ts
@@ -12,12 +12,14 @@ import type {
   PostDetailFragment,
 } from '@/graphql/__generated__/graphql'
 import {
-  dateFormatter,
   getHeroImage,
   selectMainImage,
-  toIsoStringWithTaipeiOffset,
   transformRawRelatedPosts,
 } from '@/utils/data-process'
+import {
+  toDisplayDateTimeInTaipei,
+  toIsoStringWithTaipeiOffset,
+} from '@/utils/date'
 import type { Post } from '@/types/story'
 import type { RelatedPost } from '@/types/common'
 import { getStoryPageUrl, getAuthorPageUrl } from '@/utils/site-urls'
@@ -99,9 +101,11 @@ function transformPost(
     heroCaption: rawData.heroCaption ?? '',
     publishedDateRaw: rawData.publishedDate ?? '',
     publishedTime: rawData.publishedDate
-      ? dateFormatter(rawData.publishedDate)
+      ? toDisplayDateTimeInTaipei(rawData.publishedDate)
       : '',
-    updatedTime: rawData.updatedAt ? dateFormatter(rawData.updatedAt) : '',
+    updatedTime: rawData.updatedAt
+      ? toDisplayDateTimeInTaipei(rawData.updatedAt)
+      : '',
     publishedTimeIso: rawData.publishedDate
       ? toIsoStringWithTaipeiOffset(rawData.publishedDate)
       : '',

--- a/app/story/actions.ts
+++ b/app/story/actions.ts
@@ -15,6 +15,7 @@ import {
   dateFormatter,
   getHeroImage,
   selectMainImage,
+  toIsoStringWithTaipeiOffset,
   transformRawRelatedPosts,
 } from '@/utils/data-process'
 import type { Post } from '@/types/story'
@@ -99,6 +100,10 @@ function transformPost(
     publishedDateRaw: rawData.publishedDate ?? '',
     publishedTime: dateFormatter(rawData.publishedDate) ?? '',
     updatedTime: rawData.updatedAt ? dateFormatter(rawData.updatedAt) : '',
+    publishedTimeIso: toIsoStringWithTaipeiOffset(rawData.publishedDate),
+    updatedTimeIso: rawData.updatedAt
+      ? toIsoStringWithTaipeiOffset(rawData.updatedAt)
+      : '',
     postMainImage,
     sections,
     isAdult: rawData.isAdult ?? false,

--- a/app/story/actions.ts
+++ b/app/story/actions.ts
@@ -98,9 +98,13 @@ function transformPost(
     subtitle: rawData.subtitle ?? '',
     heroCaption: rawData.heroCaption ?? '',
     publishedDateRaw: rawData.publishedDate ?? '',
-    publishedTime: dateFormatter(rawData.publishedDate) ?? '',
+    publishedTime: rawData.publishedDate
+      ? dateFormatter(rawData.publishedDate)
+      : '',
     updatedTime: rawData.updatedAt ? dateFormatter(rawData.updatedAt) : '',
-    publishedTimeIso: toIsoStringWithTaipeiOffset(rawData.publishedDate),
+    publishedTimeIso: rawData.publishedDate
+      ? toIsoStringWithTaipeiOffset(rawData.publishedDate)
+      : '',
     updatedTimeIso: rawData.updatedAt
       ? toIsoStringWithTaipeiOffset(rawData.updatedAt)
       : '',

--- a/types/external.ts
+++ b/types/external.ts
@@ -8,6 +8,8 @@ export type ExternalPost = {
   externalsLink: string
   publishedTime: string
   updatedTime: string
+  publishedTimeIso: string
+  updatedTimeIso: string
   brief: string
   content: string
   tags: {

--- a/types/story.ts
+++ b/types/story.ts
@@ -15,6 +15,8 @@ export type Post = {
   publishedDateRaw: string
   publishedTime: string
   updatedTime: string
+  publishedTimeIso: string
+  updatedTimeIso: string
   postMainImage: HeroImage
   sections: { name: string; color: string; slug: string }[]
   categories: { name: string; slug: string }[]

--- a/utils/data-process.ts
+++ b/utils/data-process.ts
@@ -14,8 +14,7 @@ import type {
   Shorts,
 } from '@/types/common'
 import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
-import timezone from 'dayjs/plugin/timezone'
+import { toDisplayDateTimeInTaipei } from './date'
 import type { createErrorLogger } from './log/common'
 import type {
   latestShortsSchema,
@@ -105,18 +104,6 @@ const getHeroImage = (
       },
     }
   }
-}
-
-const dateFormatter = (date: string) => {
-  dayjs.extend(utc)
-  dayjs.extend(timezone)
-  return dayjs(date).utc().tz('Asia/Taipei').format('YYYY/MM/DD HH:mm:ss')
-}
-
-const toIsoStringWithTaipeiOffset = (date: dayjs.ConfigType) => {
-  dayjs.extend(utc)
-  dayjs.extend(timezone)
-  return dayjs(date).utc().tz('Asia/Taipei').format('YYYY-MM-DDTHH:mm:ssZ')
 }
 
 type DataFetchFunction<T> = () => Promise<T>
@@ -238,7 +225,7 @@ const transformRawPost = (rawPost: RawPost): PostData => {
 
   const id = rawPost.id
   const title = rawPost.title ?? ''
-  const formattedDate = dateFormatter(rawPost.publishedDate)
+  const formattedDate = toDisplayDateTimeInTaipei(rawPost.publishedDate)
 
   if (isPostFromGQL || isPostFromJSON) {
     const link = getStoryPageUrl(id)
@@ -291,7 +278,7 @@ const transformRawPostWithSection = (
   const id = rawPost.id
   const title = rawPost.title ?? ''
   const link = getStoryPageUrl(id)
-  const publishedDate = dateFormatter(rawPost.publishedDate) ?? ''
+  const publishedDate = toDisplayDateTimeInTaipei(rawPost.publishedDate) ?? ''
   const heroImage = getHeroImage(rawPost.heroImage)
   const brief = getFirstParagraphFromApiData(rawPost.apiDataBrief) ?? ''
   const sectionName = rawPost.sections?.[0]?.name ?? DEFAULT_SECTION_NAME
@@ -415,8 +402,6 @@ const getDescriptionFromTagPosts = (posts: TagPost[]) => {
 
 export {
   getHeroImage,
-  dateFormatter,
-  toIsoStringWithTaipeiOffset,
   createDataFetchingChain,
   selectMainImage,
   transformLatestShorts,

--- a/utils/data-process.ts
+++ b/utils/data-process.ts
@@ -113,6 +113,12 @@ const dateFormatter = (date: string) => {
   return dayjs(date).utc().tz('Asia/Taipei').format('YYYY/MM/DD HH:mm:ss')
 }
 
+const toIsoStringWithTaipeiOffset = (date: dayjs.ConfigType) => {
+  dayjs.extend(utc)
+  dayjs.extend(timezone)
+  return dayjs(date).utc().tz('Asia/Taipei').format('YYYY-MM-DDTHH:mm:ssZ')
+}
+
 type DataFetchFunction<T> = () => Promise<T>
 
 const createDataFetchingChain = async <T>(
@@ -410,6 +416,7 @@ const getDescriptionFromTagPosts = (posts: TagPost[]) => {
 export {
   getHeroImage,
   dateFormatter,
+  toIsoStringWithTaipeiOffset,
   createDataFetchingChain,
   selectMainImage,
   transformLatestShorts,

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,0 +1,17 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+const formatInTaipei = (date: dayjs.ConfigType, format: string) =>
+  dayjs(date).utc().tz('Asia/Taipei').format(format)
+
+const toDisplayDateTimeInTaipei = (date: dayjs.ConfigType) =>
+  formatInTaipei(date, 'YYYY/MM/DD HH:mm:ss')
+
+const toIsoStringWithTaipeiOffset = (date: dayjs.ConfigType) =>
+  formatInTaipei(date, 'YYYY-MM-DDTHH:mm:ssZ')
+
+export { toDisplayDateTimeInTaipei, toIsoStringWithTaipeiOffset }

--- a/utils/post.ts
+++ b/utils/post.ts
@@ -5,7 +5,7 @@ import type { HeaderData, LatestPost, PopularNews } from '@/types/common'
 import { DEFAULT_SECTION_NAME } from '@/constants/misc'
 import { getHeroImage, getSectionColor, getCategoryColor } from './data-process'
 import { getPostPageUrl } from './site-urls'
-import { dateFormatter } from './data-process'
+import { toDisplayDateTimeInTaipei } from './date'
 
 const hasExternalLink = (
   rawPost: z.infer<typeof rawLatestPostSchema>
@@ -90,7 +90,7 @@ const transformRawLatestPost = (
     postName: title,
     postBrief: brief,
     heroImage: getHeroImage(heroImage),
-    publishedDate: dateFormatter(publishedDate),
+    publishedDate: toDisplayDateTimeInTaipei(publishedDate),
     link: getPostPageUrl(id, !!partner),
   }
 }
@@ -120,7 +120,7 @@ const transformRawPopularPost = (
     postName: title,
     postBrief: brief,
     heroImage: getHeroImage(heroImage),
-    publishedDate: dateFormatter(publishedDate),
+    publishedDate: toDisplayDateTimeInTaipei(publishedDate),
     link: getPostPageUrl(id),
   }
 }


### PR DESCRIPTION
## Additions
  
  - Add `toIsoStringWithTaipeiOffset` helper (utils/data-process.ts) that converts a date to a Taipei (+08:00) ISO 8601 string.
  - Add `publishedTimeIso` / `updatedTimeIso` fields to the story `Post` and external `ExternalPost` types, computed in their transform functions.
  - Output published/modified time <meta> tags in <head> on both story and external article pages: pubdate,
  article:published_time, lastmod, article:modified_time.
  
## Removals

  - N/A

## Changes

  - Compute the ISO time in the transform layer from the raw UTC date (rawData.publishedDate / rawData.updatedAt) .
  - Align story & external JSON-LD (NewsArticle) datePublished / dateModified to the same Taipei ISO format 
  
## Testing

  -  view-source on a story / external page and confirm the meta tags appear inside <head> with +08:00 times.
  -  view-source on a story / external page and confirm the `datePublished` `dateModified` in JSON-LD  with +08:00 times.
  
## Screenshots

  - N/A

## Todos

  - N/A
  
## Task Links
- [[鏡報]JSONLD跟Header Tag增加最後修改時間，並修改為台灣時區](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1215575293874897?focus=true)