### PR TITLE
fix: adjust promote-topic card to landscape layout and reposition

### DIFF
--- a/app/_components/promote-topic/item.tsx
+++ b/app/_components/promote-topic/item.tsx
@@ -13,16 +13,16 @@ export default function PromoteTopicItem({ post }: Props) {
 
   return (
     <a href={getTopicPageUrl(slug)} className="block" target="_blank">
-      <div className="relative w-[75px] overflow-hidden rounded-[10px] bg-mirror-blue-700 shadow-[0_2.47px_2.47px_0_#00000040] lg:w-[120px]">
-        <div className="aspect-[74/74] lg:aspect-[120/120]">
+      <div className="relative w-[124px] overflow-hidden rounded-[10px] bg-mirror-blue-700">
+        <div className="aspect-[3/2]">
           <CustomImage
             images={heroImage.resized}
             alt={`推廣專題-${name}`}
             className="size-full object-cover"
           />
         </div>
-        <div className="h-10 lg:h-16">
-          <p className="line-clamp-2 px-[7px] pt-[2px] text-[10px] font-medium leading-[1.2] text-mirror-blue-200 lg:pt-[5px] lg:text-base lg:leading-[1.2]">
+        <div className="h-14">
+          <p className="line-clamp-1 px-3 pt-[10px] text-base font-medium leading-[1.2] text-mirror-blue-200 lg:leading-[1.2]">
             {name}
           </p>
         </div>

--- a/app/_components/promote-topic/item.tsx
+++ b/app/_components/promote-topic/item.tsx
@@ -22,7 +22,7 @@ export default function PromoteTopicItem({ post }: Props) {
           />
         </div>
         <div className="h-14">
-          <p className="line-clamp-1 px-3 pt-[10px] text-base font-medium leading-[1.2] text-mirror-blue-200 lg:leading-[1.2]">
+          <p className="line-clamp-1 px-3 pt-[10px] text-base font-medium leading-[1.2] text-mirror-blue-200">
             {name}
           </p>
         </div>

--- a/app/_components/promote-topic/swiper-component.tsx
+++ b/app/_components/promote-topic/swiper-component.tsx
@@ -21,7 +21,7 @@ export default function SwiperComponent({ list }: Props) {
   if (!visible || !validList.length) return null
 
   return (
-    <div className="fixed right-[20px] top-1/2 z-promote-topic w-[75px] lg:w-[120px]">
+    <div className="fixed right-[20px] top-1/4 z-promote-topic w-[124px] lg:top-[45%]">
       <NextImage
         onClick={() => setVisible(false)}
         width={20}
@@ -44,7 +44,7 @@ export default function SwiperComponent({ list }: Props) {
           delay: 5000,
         }}
         loop={validList.length > 1}
-        className="relative"
+        className="relative overflow-hidden rounded-[10px] shadow-[0_2.47px_2.47px_0_#00000040]"
       >
         {validList.map((item) => (
           <SwiperSlide key={item.id} className="relative">


### PR DESCRIPTION
## Additions

- N/A

## Removals

- N/A

## Changes

- Switch card image from 1:1 to 3:2 aspect with fixed 124px width across breakpoints
- Clamp title to a single line
- Move shadow and rounded corners from each item to the swiper wrapper
- Reposition floating card to top-1/4 on mobile and top-[45%] on desktop

## Testing

- Verified the card image renders at a 3:2 aspect ratio
- Verified the title is clamped to a single line
- Verified the floating card is positioned at top-1/4 on mobile and top-[45%] on desktop

## Screenshots

- N/A

## Todos

- N/A

## Task Links

- [[鏡報]Promote topic調整](https://app.asana.com/1/614399484723017/project/1215753750830181/task/1215819239215629?focus=true)