### PR TITLE
fix: adjust preferred source icon shadow, position, and href

### DIFF
--- a/app/_components/preferred-source/preferred-source-icon.tsx
+++ b/app/_components/preferred-source/preferred-source-icon.tsx
@@ -1,5 +1,4 @@
 import NextImage from 'next/image'
-import { SITE_URL } from '@/constants/config'
 import { SHARE_BAR_ICON_SIZE } from '@/constants/misc'
 
 const VARIANT = {
@@ -21,7 +20,7 @@ export default function PreferredSourceIcon({ className, variant }: Props) {
 
   return (
     <a
-      href={`https://google.com/preferences/source?q=${SITE_URL.replace('https://', '')}`}
+      href="https://www.google.com/preferences/source?q=mirrordaily.news"
       target="_blank"
       rel="noopener noreferrer"
       className={className}

--- a/app/external/[id]/components/article-intro.tsx
+++ b/app/external/[id]/components/article-intro.tsx
@@ -52,7 +52,7 @@ export default function ArticleIntro({ externalPost }: Props) {
         <h1 className="text-2xl font-black leading-[1.2] text-[#212944] lg:mb-4">
           {externalPost.title}
         </h1>
-        <div className="fixed bottom-[135px] right-3 z-story-share-bar space-y-2 md:hidden">
+        <div className="fixed bottom-[135px] right-3 z-story-share-bar space-y-2 [filter:drop-shadow(0px_1px_2px_#0000004D)_drop-shadow(0px_2px_8px_#0000001A)] md:hidden">
           <PreferredSourceIcon variant="mobile" />
           <SocialShareBar title={externalPost.title} direction="vertical" />
         </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -141,7 +141,7 @@ export default function RootLayout({
           <PromoteTopicSection />
           <PreferredSourceIcon
             variant="desktop"
-            className="fixed right-[20px] top-[65%] z-preferred-source hidden drop-shadow-[0px_4px_4px_#00000040] md:block"
+            className="fixed right-[20px] top-[65%] z-preferred-source hidden drop-shadow-[0px_4px_4px_#00000040] md:block lg:top-[calc(45%_+_155px)]"
           />
         </StoreProvider>
       </body>

--- a/app/story/_components/hero-section.tsx
+++ b/app/story/_components/hero-section.tsx
@@ -86,7 +86,7 @@ export default function HeroSection({ postData }: Props) {
           </h2>
         )}
 
-        <div className="fixed bottom-[135px] right-3 z-story-share-bar space-y-2 md:hidden">
+        <div className="fixed bottom-[135px] right-3 z-story-share-bar space-y-2 [filter:drop-shadow(0px_1px_2px_#0000004D)_drop-shadow(0px_2px_8px_#0000001A)] md:hidden">
           <PreferredSourceIcon variant="mobile" />
           <SocialShareBar
             title={postData.title}


### PR DESCRIPTION
## Additions
  
- N/A
  
## Removals

- N/A

## Changes

  - Add the mobile drop-shadow on the share-bar container in story (`hero-section.tsx`) and external (`article-intro.tsx`), so the SocialShareBar icons share the same shadow.
  - Reposition the desktop floating preferred-source icon on lg to `top-[calc(45% + 155px)]` so it sits below the promote-topic widget and no longer overlaps on short/flat viewports.
  - Hardcode the preferred-source href to the production domain (q=mirrordaily.news), replacing the SITE_URL-derived value.

## Testing

  - On mobile story (/story/[id]) and external (/external/[id]): confirm the preferred-source icon and the FB / LINE / share icons all carry the same drop-shadow in the vertical share bar.
  - On desktop (lg): confirm the floating icon sits below the promote-topic widget without overlapping, including on short / flat (wide) viewports.
  - Clicking the icon opens the Google preferred-source URL with the production domain.

## Screenshots

- N/A

## Todos

- N/A