### PR TITLE
refactor(header): regroup search button and contact links layout

### DIFF
--- a/shared-components/header/ui-header.tsx
+++ b/shared-components/header/ui-header.tsx
@@ -88,36 +88,34 @@ export default function UiHeader({
             />
           </a>
           <div className="ml-auto lg:ml-[initial]">
-            <div className="flex space-x-4">
-              <div className="ml-auto mr-5 flex shrink-0 md:gap-x-[5px] lg:mr-0 lg:gap-x-[7px]">
-                <a
-                  className={`${headerGtmEvents.search} flex h-[26px] w-24 items-center justify-center gap-x-[10px] rounded-[29px] border-2 border-white text-sm leading-normal text-white md:w-[124px]`}
-                  href="/search"
-                >
-                  <span className="md:hidden">AI 搜尋</span>
-                  <span className="hidden md:block">AI 智慧搜尋</span>
-                  <span className="relative inline-block size-5">
-                    <NextImage src={IconSearch} fill={true} alt="搜尋" />
-                  </span>
-                </a>
-              </div>
-              {CONTACT_LINKS_WITHOUT_FIRST.map((contactLink) => {
-                return (
-                  <a
-                    key={contactLink.href + contactLink.name}
-                    className={`${
-                      headerGtmEvents[contactLink?.gtmKey] || ''
-                    } header-submit-button`}
-                    href={contactLink.href}
-                  >
-                    {contactLink.headerSubmitButtonName}
-                  </a>
-                )
-              })}
+            <div className="ml-auto mr-5 flex lg:mr-0">
+              <a
+                className={`${headerGtmEvents.search} flex h-[26px] w-24 items-center justify-center gap-x-[10px] rounded-[29px] border-2 border-white text-sm leading-normal text-white md:w-[124px] lg:w-full`}
+                href="/search"
+              >
+                <span className="md:hidden">AI 搜尋</span>
+                <span className="hidden md:block">AI 智慧搜尋</span>
+                <span className="relative inline-block size-5">
+                  <NextImage src={IconSearch} fill={true} alt="搜尋" />
+                </span>
+              </a>
             </div>
             <div className="mt-[13px] hidden items-center justify-between lg:flex">
-              <div className="flex lg:mr-[7px]">
+              <div className="flex items-center space-x-[18px] lg:mr-[18px]">
                 <ImagesAd />
+                {CONTACT_LINKS_WITHOUT_FIRST.map((contactLink) => {
+                  return (
+                    <a
+                      key={contactLink.href + contactLink.name}
+                      className={`${
+                        headerGtmEvents[contactLink?.gtmKey] || ''
+                      } header-submit-button`}
+                      href={contactLink.href}
+                    >
+                      {contactLink.headerSubmitButtonName}
+                    </a>
+                  )
+                })}
               </div>
               <div className="flex lg:shrink-0 lg:grow-0 lg:gap-x-2">
                 {ExtendedSocialLinks.map(({ name, href, icon }) => {


### PR DESCRIPTION
## Additions

- N/A

## Removals

- N/A

## Changes

- 調整 ui-header.tsx 樣式:將 AI 搜尋按鈕獨立成一區,並把聯絡連結移到 lg 版 ImagesAd 同一列,調整間距

## Testing

- 桌機(lg 以上):搜尋按鈕、聯絡連結、ImagesAd 排列與間距正確
- 各斷點 RWD 無跑版

## Screenshots

- N/A

## Todos

- N/A

## Task Links

- [[鏡報刊頭調整]類別頁前面放topic，並於mobile能顯示](https://app.asana.com/1/614399484723017/project/1215753750830181/task/1215267322292430?focus=true)