### PR TITLE
fix(promote-topic): hide promote topic on search page

### DIFF
--- a/app/_components/promote-topic/swiper-component.tsx
+++ b/app/_components/promote-topic/swiper-component.tsx
@@ -9,6 +9,7 @@ import type { PromoteTopicData } from '@/types/homepage'
 import { useState } from 'react'
 import IConClose from '@/public/icons/close.svg'
 import NextImage from 'next/image'
+import { usePathname } from 'next/navigation'
 
 type Props = {
   list: PromoteTopicData[]
@@ -16,9 +17,11 @@ type Props = {
 
 export default function SwiperComponent({ list }: Props) {
   const [visible, setVisible] = useState(true)
+  const pathname = usePathname()
+  const isSearchPage = pathname.startsWith('/search')
   const validList = list.filter((item) => item.topics)
 
-  if (!visible || !validList.length) return null
+  if (!visible || !validList.length || isSearchPage) return null
 
   return (
     <div className="fixed right-[20px] top-1/4 z-promote-topic w-[124px] lg:top-[45%]">


### PR DESCRIPTION
## Additions

  - N/A

## Removals

  - Search 頁（`/search`、`/search/gse-search`）不再顯示右側的 promote-topic 浮動卡片

## Changes

  - 用`usePathname()` 判斷目前路徑，路徑以 `/search` 開頭時不渲染。

## Testing

  - 進入 `/search` 頁確認 promote-topic 已隱藏；從 search 頁導航到其他頁面後確認恢復顯示

## Screenshots

  - N/A

## Todos

  - N/A
  
## Task
[[鏡報]搜索頁不顯示promote topic](https://app.asana.com/1/614399484723017/project/1216190579632682/task/1216189982549745?focus=true)