### PR TITLE
fix(story): share the currently scrolled article in fixed share bar

### DIFF
--- a/app/story/_components/hero-section.tsx
+++ b/app/story/_components/hero-section.tsx
@@ -8,8 +8,6 @@ import NextImage from 'next/image'
 import { storyGtmEvents } from '@/constants/gtm'
 import type { Post } from '@/types/story'
 import { DEFAULT_SECTION_COLOR, DEFAULT_SECTION_NAME } from '@/constants/misc'
-import SocialShareBar from '@/shared-components/social-share-bar'
-import PreferredSourceIcon from '@/app/_components/preferred-source/preferred-source-icon'
 
 type Props = {
   postData: Post
@@ -85,15 +83,6 @@ export default function HeroSection({ postData }: Props) {
             {postData.subtitle}
           </h2>
         )}
-
-        <div className="fixed bottom-[135px] right-3 z-story-share-bar space-y-2 [filter:drop-shadow(0px_1px_2px_#0000004D)_drop-shadow(0px_2px_8px_#0000001A)] md:hidden">
-          <PreferredSourceIcon variant="mobile" />
-          <SocialShareBar
-            title={postData.title}
-            link={postData.link}
-            direction="vertical"
-          />
-        </div>
       </div>
 
       <div className="order-3 mb-4 w-full px-5 md:mb-6 md:px-0 lg:order-2 lg:mb-4">

--- a/app/story/_components/story-infinite-articles.tsx
+++ b/app/story/_components/story-infinite-articles.tsx
@@ -8,6 +8,8 @@ import ArticleSectionClient from './story-infinite-article-section-client'
 import { fetchNextPostBySameSectionAction } from '../actions'
 import { DableWordSecond, PopInRecommendWord } from './ads'
 import BottomAd from '@/shared-components/bottom-ad'
+import SocialShareBar from '@/shared-components/social-share-bar'
+import PreferredSourceIcon from '@/app/_components/preferred-source/preferred-source-icon'
 
 const articleAds = [
   <PopInRecommendWord key="popin-word" />,
@@ -31,6 +33,7 @@ export default function StoryInfiniteArticles({
   const [posts, setPosts] = useState<Post[]>([])
   const [fetchCount, setFetchCount] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
+  const [activeArticleId, setActiveArticleId] = useState(initialPost.id)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
 
   const articlesForSpy = useMemo(
@@ -40,6 +43,8 @@ export default function StoryInfiniteArticles({
     ],
     [initialPost.id, initialPost.title, posts]
   )
+
+  const activePost = posts.find((p) => p.id === activeArticleId) ?? initialPost
 
   useEffect(() => {
     if (!sentinelRef.current) return
@@ -103,7 +108,20 @@ export default function StoryInfiniteArticles({
 
   return (
     <>
-      <StoryScrollSpy articles={articlesForSpy} />
+      <StoryScrollSpy
+        articles={articlesForSpy}
+        onActiveIdChange={setActiveArticleId}
+      />
+
+      {/* 分享按鈕 fixed 在 viewport 上，統一渲染一份，分享目前捲動到的文章 */}
+      <div className="fixed bottom-[135px] right-3 z-story-share-bar space-y-2 [filter:drop-shadow(0px_1px_2px_#0000004D)_drop-shadow(0px_2px_8px_#0000001A)] md:hidden">
+        <PreferredSourceIcon variant="mobile" />
+        <SocialShareBar
+          title={activePost.title}
+          link={activePost.link}
+          direction="vertical"
+        />
+      </div>
 
       {/* sentinel：滑到底時觸發下一篇 */}
       <div ref={sentinelRef} className="h-px w-full" />

--- a/app/story/_components/story-scroll-spy.tsx
+++ b/app/story/_components/story-scroll-spy.tsx
@@ -11,7 +11,13 @@ type Article = {
   title: string
 }
 
-export function StoryScrollSpy({ articles }: { articles: Article[] }) {
+export function StoryScrollSpy({
+  articles,
+  onActiveIdChange,
+}: {
+  articles: Article[]
+  onActiveIdChange?: (id: string) => void
+}) {
   const activeIdRef = useRef<string | null>(null)
   const titleById = useMemo(
     () => new Map(articles.map((a) => [a.id, a.title])),
@@ -32,6 +38,7 @@ export function StoryScrollSpy({ articles }: { articles: Article[] }) {
         if (rect.bottom > 0 && rect.top < window.innerHeight) {
           if (activeIdRef.current !== ssrFirstId) {
             activeIdRef.current = ssrFirstId
+            onActiveIdChange?.(ssrFirstId)
             const nextPath = getStoryPath(ssrFirstId)
             if (window.location.pathname !== nextPath) {
               window.history.replaceState(
@@ -57,6 +64,7 @@ export function StoryScrollSpy({ articles }: { articles: Article[] }) {
       if (rect.top <= y && rect.bottom > y) {
         if (activeIdRef.current === a.id) return
         activeIdRef.current = a.id
+        onActiveIdChange?.(a.id)
 
         const nextPath = getStoryPath(a.id)
         if (window.location.pathname !== nextPath) {


### PR DESCRIPTION
 無限捲動載入的每篇文章都各自渲染一份 fixed 定位的 SocialShareBar，全部疊在 viewport 的同一個位置，導致最後載入那篇文章的分享按鈕永遠蓋在最上層。改為只渲染一份 fixed 分享按鈕，由 scroll spy 判定的當前文章來驅動分享內容。

## Additions

- `StoryScrollSpy` 新增 optional `onActiveIdChange` callback，在 active 文章切換時通知外層
- `StoryInfiniteArticles` 新增 `activeArticleId` state（初始為 `initialPost.id`），並統一渲染唯一一份 fixed 的 `SocialShareBar` + `PreferredSourceIcon`，分享對象為目前捲動到的文章

## Removals

- 移除 `HeroSection` 內 fixed 定位的 `SocialShareBar` + `PreferredSourceIcon` 區塊

## Changes

- N/A

## Testing

- 手機版（< md）進入文章頁，往下捲動觸發載入多篇文章後，點擊右下角分享按鈕，確認分享的標題與連結為目前閱讀中的文章

## Screenshots

- N/A

## Todos

- N/A

## Task Links

- [[鏡報]內文頁分享按鈕異常](https://app.asana.com/1/614399484723017/project/1216190579632682/task/1215993608719077?focus=true)