### PR TITLE
fix(editor-choice): align title line-height with clamped container height

### DIFF
--- a/app/_components/editor-choice/swiper-component.tsx
+++ b/app/_components/editor-choice/swiper-component.tsx
@@ -61,7 +61,7 @@ export default function SwiperComponent({ list }: Props) {
                   />
                   <div className="absolute inset-0 md:bg-[linear-gradient(180deg,rgba(0,0,0,0.48)_6.69%,rgba(110,110,110,0.24)_17.20%,rgba(217,217,217,0.00)_20.52%,rgba(255,255,255,0)_23.25%,rgba(255,255,255,0)_74.52%,rgba(217,217,217,0.00)_74.52%,rgba(43,43,43,0.64)_83.44%,rgba(0,0,0,0.80)_96.18%)]" />
                 </div>
-                <p className="mt-5 line-clamp-3 h-[85px] text-xl font-bold leading-normal text-[#000928] group-hover/slide:text-[#575D71] group-active/slide:text-[#575D71] md:absolute md:bottom-3 md:left-5 md:m-0 md:line-clamp-2 md:h-auto md:max-h-[58px] md:w-[440px] md:text-white md:group-hover/slide:text-white md:group-hover/slide:underline md:group-active/slide:text-white md:group-active/slide:underline lg:bottom-7 lg:left-7 lg:max-h-[69px] lg:w-[654px] lg:text-3xl lg:font-normal">
+                <p className="mt-5 line-clamp-3 h-[85px] text-xl font-bold leading-normal text-[#000928] group-hover/slide:text-[#575D71] group-active/slide:text-[#575D71] md:absolute md:bottom-3 md:left-5 md:m-0 md:line-clamp-2 md:h-auto md:max-h-[58px] md:w-[440px] md:text-white md:group-hover/slide:text-white md:group-hover/slide:underline md:group-active/slide:text-white md:group-active/slide:underline lg:bottom-7 lg:left-7 lg:max-h-[90px] lg:w-[654px] lg:text-[32px] lg:font-normal lg:leading-[45px]">
                   {postName}
                 </p>
               </a>

--- a/app/_components/editor-choice/swiper-component.tsx
+++ b/app/_components/editor-choice/swiper-component.tsx
@@ -61,7 +61,7 @@ export default function SwiperComponent({ list }: Props) {
                   />
                   <div className="absolute inset-0 md:bg-[linear-gradient(180deg,rgba(0,0,0,0.48)_6.69%,rgba(110,110,110,0.24)_17.20%,rgba(217,217,217,0.00)_20.52%,rgba(255,255,255,0)_23.25%,rgba(255,255,255,0)_74.52%,rgba(217,217,217,0.00)_74.52%,rgba(43,43,43,0.64)_83.44%,rgba(0,0,0,0.80)_96.18%)]" />
                 </div>
-                <p className="mt-5 line-clamp-3 h-[85px] text-xl font-bold leading-normal text-[#000928] group-hover/slide:text-[#575D71] group-active/slide:text-[#575D71] md:absolute md:bottom-3 md:left-5 md:m-0 md:line-clamp-2 md:h-auto md:max-h-[58px] md:w-[440px] md:text-white md:group-hover/slide:text-white md:group-hover/slide:underline md:group-active/slide:text-white md:group-active/slide:underline lg:bottom-7 lg:left-7 lg:max-h-[90px] lg:w-[654px] lg:text-[32px] lg:font-normal lg:leading-[45px]">
+                <p className="mt-5 line-clamp-3 h-[84px] text-xl font-bold leading-[28px] text-[#000928] group-hover/slide:text-[#575D71] group-active/slide:text-[#575D71] md:absolute md:bottom-3 md:left-5 md:m-0 md:line-clamp-2 md:h-auto md:max-h-[58px] md:w-[440px] md:leading-[29px] md:text-white md:group-hover/slide:text-white md:group-hover/slide:underline md:group-active/slide:text-white md:group-active/slide:underline lg:bottom-7 lg:left-7 lg:max-h-[90px] lg:w-[654px] lg:text-[32px] lg:font-normal lg:leading-[45px]">
                   {postName}
                 </p>
               </a>


### PR DESCRIPTION
編輯精選（Editor's Choice）標題會因為容器高度不足，而裁掉最後一行，起因是 Chrome `150.0.7871.24` 的調整，不小心導致了 `-webkit-line-clamp` 的機制調整，直到 2026/07/15 發布的新版本，Chrome 才修復，讓 `-webkit-line-clamp`
  不再因高度截斷行數。因此這段期間，有更新 / 未更新 Chrome 的裝置會看到不一樣的結果，理論上，有更新到新版的 Chrome，就不會再出現（除非有啟用 Experimental Web Platform features）。

不過原本的高度設定確實就是不足的，此次微調了各個斷點的 `max-height`，讓 max-height 與文字的行數一致，並且確認目前高度與現行設計稿一致。

## Additions

  - N/A

## Removals

  - N/A

## Changes

  - `SwiperComponent` 標題手機版行高由 `leading-normal` 改為 `leading-[28px]`。
  - `SwiperComponent` 標題新增 `md:leading-[29px]`，在維持 `md:max-h-[58px]` 不變的前提下讓 2 行剛好等於 58px
  - `SwiperComponent` 標題 lg 以上字級由 `lg:text-3xl`（30px）改為 `lg:text-[32px]`，並明確指定 `lg:leading-[45px]`
  - `SwiperComponent` 標題 lg 以上 `max-height` 由 `lg:max-h-[69px]` 改為 `lg:max-h-[90px]`（2 行 × 45px）

## Testing

  - 桌機版（≥ lg）首頁編輯精選，確認 2 行標題完整顯示不被裁切，且 hover 時 2 行都有底線
  - 平板（md）確認 2 行標題完整顯示
  - 手機版（< md）確認 3 行標題完整顯示

## Screenshots

  - N/A

## Todos

  - N/A
  
## Task Links

- [[鏡報]首頁編輯精選變僅一行](https://app.asana.com/1/614399484723017/project/1216190579632682/task/1216549799741724?focus=true)