### PR TITLE
feat(header): implement sticky layout and separate non-sticky flash news

### DIFF
--- a/app/topic/layout.tsx
+++ b/app/topic/layout.tsx
@@ -8,9 +8,7 @@ export default function Layout({
 }>) {
   return (
     <>
-      <div className="fixed inset-x-0 top-0 z-topic-header-mobile w-full bg-white md:static">
-        <Header />
-      </div>
+      <Header />
       {/* main content */}
       <div className="flex w-full shrink-0 grow flex-col pt-44 md:pt-0">
         {children}

--- a/shared-components/gpt-ad/base-gpt-ad.tsx
+++ b/shared-components/gpt-ad/base-gpt-ad.tsx
@@ -71,7 +71,7 @@ export default function BaseGptAd({
         )}
       >
         {isDebugMode && (
-          <span className="absolute left-0 top-0 z-[9999] bg-red-500 px-1 py-0.5 text-[12px] text-white">
+          <span className="absolute left-0 top-0 z-ad bg-red-500 px-1 py-0.5 text-[12px] text-white">
             {slotId}
           </span>
         )}

--- a/shared-components/gpt-ad/full-screen-ad.tsx
+++ b/shared-components/gpt-ad/full-screen-ad.tsx
@@ -118,7 +118,7 @@ export default function FullScreenAd({ slotKey }: Props) {
     <>
       {/* 蓋板廣告容器 */}
       <div
-        className={`fixed inset-0 z-[9999] items-center justify-center overflow-hidden bg-black/70 md:hidden ${
+        className={`fixed inset-0 z-ad items-center justify-center overflow-hidden bg-black/70 md:hidden ${
           isAdVisible ? 'flex' : 'hidden'
         }`}
       >

--- a/shared-components/gpt-ad/sticky-ad.tsx
+++ b/shared-components/gpt-ad/sticky-ad.tsx
@@ -142,7 +142,7 @@ export default function StickyAd({
   return (
     <div
       id="md-sticky"
-      className="fixed inset-x-0 bottom-0 z-[9999] h-[100px] items-center justify-center bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.1)] lg:h-[90px]"
+      className="fixed inset-x-0 bottom-0 z-ad h-[100px] items-center justify-center bg-white shadow-[0_-2px_8px_rgba(0,0,0,0.1)] lg:h-[90px]"
       style={{ display: shouldShow ? 'flex' : 'none' }}
     >
       <div id="gpt-sticky" className="flex items-center justify-center"></div>

--- a/shared-components/header/ui-header.tsx
+++ b/shared-components/header/ui-header.tsx
@@ -73,81 +73,87 @@ export default function UiHeader({
   )
 
   return (
-    <header className="w-full">
-      <div className="flex h-[64px] items-center justify-center bg-mirror-blue-700 md:h-[68px] lg:h-[101px]">
-        <div className="flex flex-1 items-center justify-between pl-4 pr-[21px] md:max-w-[1000px] md:pl-5 lg:max-w-screen-lg lg:px-9">
-          <a
-            href="/"
-            className={`${headerGtmEvents.logo} relative h-12 w-[100px] md:h-[42px] md:w-[88px] lg:h-[77px] lg:w-[160px] lg:shrink-0`}
-          >
-            <NextImage
-              src={IconLogo}
-              fill
-              alt="Logo"
-              className="aspect-[150/42] md:aspect-auto"
-            />
-          </a>
-          <div className="ml-auto lg:ml-[initial]">
-            <div className="ml-auto mr-5 flex lg:mr-0">
-              <a
-                className={`${headerGtmEvents.search} flex h-[26px] w-24 items-center justify-center gap-x-[10px] rounded-[29px] border-2 border-white text-sm leading-normal text-white md:w-[124px] lg:w-full`}
-                href="/search"
-              >
-                <span className="md:hidden">AI 搜尋</span>
-                <span className="hidden md:block">AI 智慧搜尋</span>
-                <span className="relative inline-block size-5">
-                  <NextImage src={IconSearch} fill={true} alt="搜尋" />
-                </span>
-              </a>
-            </div>
-            <div className="mt-[13px] hidden items-center justify-between lg:flex">
-              <div className="flex items-center space-x-[18px] lg:mr-[18px]">
-                <ImagesAd />
-                {CONTACT_LINKS_WITHOUT_FIRST.map((contactLink) => {
-                  return (
-                    <a
-                      key={contactLink.href + contactLink.name}
-                      className={`${
-                        headerGtmEvents[contactLink?.gtmKey] || ''
-                      } header-submit-button`}
-                      href={contactLink.href}
-                    >
-                      {contactLink.headerSubmitButtonName}
-                    </a>
-                  )
-                })}
+    <>
+      <header className="sticky top-0 z-global-header w-full bg-white">
+        <div className="flex h-[64px] items-center justify-center bg-mirror-blue-700 md:h-[68px] lg:h-[101px]">
+          <div className="flex flex-1 items-center justify-between pl-4 pr-[21px] md:max-w-[1000px] md:pl-5 lg:max-w-screen-lg lg:px-9">
+            <a
+              href="/"
+              className={`${headerGtmEvents.logo} relative h-12 w-[100px] md:h-[42px] md:w-[88px] lg:h-[77px] lg:w-[160px] lg:shrink-0`}
+            >
+              <NextImage
+                src={IconLogo}
+                fill
+                alt="Logo"
+                className="aspect-[150/42] md:aspect-auto"
+              />
+            </a>
+            <div className="ml-auto lg:ml-[initial]">
+              <div className="ml-auto mr-5 flex lg:mr-0">
+                <a
+                  className={`${headerGtmEvents.search} flex h-[26px] w-24 items-center justify-center gap-x-[10px] rounded-[29px] border-2 border-white text-sm leading-normal text-white md:w-[124px] lg:w-full`}
+                  href="/search"
+                >
+                  <span className="md:hidden">AI 搜尋</span>
+                  <span className="hidden md:block">AI 智慧搜尋</span>
+                  <span className="relative inline-block size-5">
+                    <NextImage src={IconSearch} fill={true} alt="搜尋" />
+                  </span>
+                </a>
               </div>
-              <div className="flex lg:shrink-0 lg:grow-0 lg:gap-x-2">
-                {ExtendedSocialLinks.map(({ name, href, icon }) => {
-                  const width = iconSizes[name] || 24
-                  return (
-                    <a
-                      key={name}
-                      href={href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={`${headerGtmEvents[name]}`}
-                    >
-                      <NextImage
-                        src={icon}
-                        alt={name}
-                        width={width}
-                        height={24}
-                      />
-                    </a>
-                  )
-                })}
+              <div className="mt-[13px] hidden items-center justify-between lg:flex">
+                <div className="flex items-center space-x-[18px] lg:mr-[18px]">
+                  <ImagesAd />
+                  {CONTACT_LINKS_WITHOUT_FIRST.map((contactLink) => {
+                    return (
+                      <a
+                        key={contactLink.href + contactLink.name}
+                        className={`${
+                          headerGtmEvents[contactLink?.gtmKey] || ''
+                        } header-submit-button`}
+                        href={contactLink.href}
+                      >
+                        {contactLink.headerSubmitButtonName}
+                      </a>
+                    )
+                  })}
+                </div>
+                <div className="flex lg:shrink-0 lg:grow-0 lg:gap-x-2">
+                  {ExtendedSocialLinks.map(({ name, href, icon }) => {
+                    const width = iconSizes[name] || 24
+                    return (
+                      <a
+                        key={name}
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`${headerGtmEvents[name]}`}
+                      >
+                        <NextImage
+                          src={icon}
+                          alt={name}
+                          width={width}
+                          height={24}
+                        />
+                      </a>
+                    )
+                  })}
+                </div>
               </div>
             </div>
+            <MobileToggleAndNav sections={sections} />
           </div>
-          <MobileToggleAndNav sections={sections} />
         </div>
-      </div>
-      <hr className="h-px w-full bg-[#ccced4] md:hidden" />
-      <div className="mx-auto pb-[3px] md:max-w-[1000px] md:pb-[9px] lg:max-w-screen-lg lg:pb-[17px]">
-        <div className="mt-2 w-full overflow-x-auto overflow-y-hidden pl-4 pr-0 md:pl-5 lg:mt-[15px] lg:overflow-visible lg:px-9">
-          <NavList sections={sections} topics={topics} />
+        <hr className="h-px w-full bg-[#ccced4] md:hidden" />
+
+        <div className="mx-auto md:max-w-[1000px] lg:max-w-screen-lg">
+          <div className="w-full overflow-x-auto overflow-y-hidden py-2 pl-4 pr-0 md:pl-5 lg:overflow-visible lg:px-9 lg:py-[15px]">
+            <NavList sections={sections} topics={topics} />
+          </div>
         </div>
+      </header>
+
+      <div className="mx-auto w-full pb-[3px] md:max-w-[1000px] md:pb-[9px] lg:max-w-screen-lg lg:pb-[17px]">
         <div className="mt-[14px] flex w-full grow items-start pl-4 text-lg md:mt-[7px] md:pl-5 md:text-base lg:mt-3 lg:px-9">
           <p className="mr-[18px] mt-1 shrink-0 font-bold leading-none text-[#FF5457] md:mr-[7px] lg:mr-3">
             快訊
@@ -155,6 +161,6 @@ export default function UiHeader({
           <FlashNewsList items={flashNews} />
         </div>
       </div>
-    </header>
+    </>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,6 +63,7 @@ module.exports = {
         'promote-topic': 10,
         'preferred-source': 10,
         'promote-topic-close-button': 100,
+        'global-header': 10000,
         'upload-modal': 1000000,
         'light-box': 10000000,
         'mobile-nav': 1000000000,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,6 +63,7 @@ module.exports = {
         'promote-topic': 10,
         'preferred-source': 10,
         'promote-topic-close-button': 100,
+        ad: 9999,
         'global-header': 10000,
         'upload-modal': 1000000,
         'light-box': 10000000,


### PR DESCRIPTION
## 描述
此 PR 實現了全站 header 置頂（不含已經置頂的 shorts 頁 header)，並對 `UiHeader` 元件結構進行重構。

### 核心改動
1. **header 置頂實作 (`shared-components/header/ui-header.tsx`)**：
    - 替 `<header>` 元素套用 `sticky top-0 z-global-header bg-white` 樣式，使其在頁面滾動時置頂。
    - 新增 `bg-white` 避免 header 以下的內容穿透 header。
 2. **快訊區塊（FlashNewsList）分家**：
    - 將「快訊」移出置頂的 `<header>` 元素，讓使用者往下捲動時，快訊不會和 header 一起置頂。
 3. **Z-Index 層級設定 (`tailwind.config.js`)**：
    - 於 Tailwind 設定中新增 `global-header: 10000`，確保 header 不會被廣告遮擋。
4. **樣式微調**：
    - 因應「快訊」移除  `<header>` 元素導致部分樣式受影響，將受影響範圍恢復成「快訊」移除  `<header>` 元素前看起來的樣子，包括：將原本 `NavList` 的 margin 調整為 padding（`py-2` 與`lg:py-[15px]`）等，設計稿不變。
5. **統一管理 z-indices**：此次任務須確定 header 的 z-index 值高於全站大部分元件，發現廣告元件的 z-index 都是寫死在元件內部，且目前使用的三個廣告元件  z-index 值皆相同，故將其抽出、以變數型態集中於 `tailwind.config.js` 管理以達一目瞭然之需求，再引入各個檔案使用。

**相關資源**

- 任務卡
https://app.asana.com/1/614399484723017/project/1216190579632682/task/1216971945692128?focus=true