### PR TITLE
fix(topic): simplify JSON pagination logic using library buffering

### DIFF
--- a/app/topic/[slug]/_components/list-type/index.tsx
+++ b/app/topic/[slug]/_components/list-type/index.tsx
@@ -13,7 +13,7 @@ export default async function ListTypeListing({ slug }: Props) {
   const { postsData: initialPosts, postsCount } =
     await fetchListTypeTopicPostBySlug({
       slug,
-      take: PAGE_SIZE,
+      take: 0, // 載入整個 file 1，讓 library 緩衝多餘項目
       page: 1,
       withAmount: true,
     })
@@ -22,9 +22,11 @@ export default async function ListTypeListing({ slug }: Props) {
 
   const fetchMorePosts = async (page: number) => {
     'use server'
+    // library 的 page 直接對應 JSON 檔編號
+    // library 內部緩衝機制會在有剩餘資料時跳過 fetch，因此頁碼不會跳號
     const { postsData } = await fetchListTypeTopicPostBySlug({
       slug,
-      take: PAGE_SIZE,
+      take: 0,
       page,
     })
     return postsData

--- a/app/topic/action.ts
+++ b/app/topic/action.ts
@@ -103,12 +103,14 @@ async function fetchListTypeTopicPostBySlug({
     },
     async () => {
       const skip = PAGE_SIZE * (page - 1)
+      // take=0 代表「取整個 JSON 檔」，但 GQL 不適用此約定，改用 PAGE_SIZE
+      const gqlTake = take || PAGE_SIZE
       const rawData = await fetchGQLData(
         errorLogger,
         GetListTypeTopcPostsDocument,
         {
           slug,
-          take,
+          take: gqlTake,
           skip,
           withAmount,
         }


### PR DESCRIPTION
## Asana Task
[topic頁內容重複](https://app.asana.com/1/614399484723017/project/1216190579632682/task/1216971945692139)

## 🎯 為什麼要這樣做

- 原本專題列表在處理基於 JSON 檔案的分頁時，由於每個 JSON 檔案包含 24 筆資料，而單頁顯示數量為 12 筆，直接按頁碼分頁會導致抓取檔案序號與資料索引錯位（例如直接請求第 2 頁的 JSON 檔會跳過第 1 頁後面的 12 筆資料）。
- 為了修正此問題，改為將請求數量參數設為 `0` 以獲取整個 JSON 檔案的資料，並藉由前端列表套件的內建緩衝機制自動管理剩餘項目。當套件內有剩餘資料時會跳過 API 請求，使頁碼可以直接對應 JSON 檔案編號，避免頁碼跳號與文章位移。

## ⚠️ 修改的內容

### [專題列表分頁邏輯]
- **修改方向**：修復分頁載入偏差並簡化處理邏輯
- **內容**：
  - 調整首頁初始資料載入的數量參數，由限制單頁筆數改為取得整個檔案，以載入完整的第一個資料檔並將多餘項目寫入套件緩衝區。
  - 修改後續頁面加載函數，頁面參數直接對應 JSON 檔案編號，且同樣一次請求整個檔案。配合前端套件的緩衝處理，即可避免頁碼跳號與文章位移的問題。

## 🧪 測試步驟

### 測試案例 1：[專題列表元件的連續分頁加載]

1. 進入包含大量文章（大於 24 筆）的專題列表頁面。
2. 下拉頁面觸發第一次「載入更多」（第二頁）。
3. **預期結果**：順利顯示第 13 筆至第 24 筆文章。此時因為有初始載入時的緩衝，應不會觸發實質的 API 檔案請求，文章順序正確無重複。
4. 繼續下拉頁面觸發第二次「載入更多」（第三頁）。
5. **預期結果**：觸發載入第二個 JSON 檔，並順利顯示第 25 筆以後的文章，載入邏輯無位移。
