### PR TITLE
fix(ad): increase z-index of full-screen ad to overlay global header

### DIFF
--- a/shared-components/gpt-ad/full-screen-ad.tsx
+++ b/shared-components/gpt-ad/full-screen-ad.tsx
@@ -118,7 +118,7 @@ export default function FullScreenAd({ slotKey }: Props) {
     <>
       {/* 蓋板廣告容器 */}
       <div
-        className={`fixed inset-0 z-ad items-center justify-center overflow-hidden bg-black/70 md:hidden ${
+        className={`fixed inset-0 z-full-screen-ad items-center justify-center overflow-hidden bg-black/70 md:hidden ${
           isAdVisible ? 'flex' : 'hidden'
         }`}
       >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,6 +65,7 @@ module.exports = {
         'promote-topic-close-button': 100,
         ad: 9999,
         'global-header': 10000,
+        'full-screen-ad': 11000,
         'upload-modal': 1000000,
         'light-box': 10000000,
         'mobile-nav': 1000000000,


### PR DESCRIPTION
# 描述

- 將蓋版廣告的 `z-index` 值從原本的`9999`調整成`11000`，避免被 `z- index` 值`10000`的全站 header 遮蓋

**參考資料**

- https://app.asana.com/1/614399484723017/project/1207977476935264/task/1217568309628772?focus=true